### PR TITLE
Selection disambiguation: rank metadata fields by group divergence

### DIFF
--- a/app/src-tauri/src/disambiguate.rs
+++ b/app/src-tauri/src/disambiguate.rs
@@ -1,0 +1,677 @@
+//! Selection disambiguation: given N groups of locations, rank metadata fields by
+//! how strongly they *separate* the groups (not by which value is most common).
+//!
+//! Each field gets a value-divergence score in [0,1] chosen by its comparison type:
+//! - **Linear** numeric -> epsilon-squared from the Kruskal-Wallis H statistic
+//!   (rank-based, robust to skew/scale).
+//! - **Circular** -> one-way circular ANOVA decomposition (handles wrap-around;
+//!   350 deg and 10 deg are close).
+//! - **Categorical** (incl. tags as booleans) -> bias-corrected Cramer's V.
+//!
+//! Missing values are excluded from the value math (never treated as zero); a field's
+//! *presence* asymmetry across groups is reported separately as a coverage score.
+
+use std::collections::{HashMap, HashSet};
+use std::f64::consts::PI;
+
+use serde::Serialize;
+
+use crate::location_store::{SelectionInput, StoreState};
+use crate::map_meta::{infer_field_type, known_field_def, resolved_comparison, ComparisonType, ExtraFieldDef, ExtraFieldType};
+use crate::selections::resolve_bitmask;
+use crate::types::Location;
+use crate::util::iso_to_unix;
+
+#[cfg(test)]
+#[path = "disambiguate.test.rs"]
+mod tests;
+
+/// A group must have at least this many present values for a field before its
+/// value score is trusted; below this the field is flagged low-confidence.
+const MIN_PRESENT: u32 = 8;
+/// How many top categories to surface per group in a categorical summary.
+const TOP_N: usize = 3;
+/// Fields excluded from analysis: they encode the location/answer itself rather than
+/// an in-round visual tell, so flagging them as "divergent" is pointless.
+const EXCLUDED_FIELDS: &[&str] = &["countryCode", "timezone"];
+
+#[derive(Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct DisambiguateResult {
+    /// Fields ranked by divergence (most separating first).
+    pub fields: Vec<FieldDivergence>,
+    /// Locations dropped because they belonged to more than one group.
+    pub excluded_overlap: u32,
+    /// Per-group labeled location count (after overlap removal), input order.
+    pub group_sizes: Vec<u32>,
+}
+
+/// How the numeric per-group summaries should be rendered. Numeric fields are
+/// compared as plain numbers internally even when they're dates, so the UI needs
+/// this to turn a month-index or unix timestamp back into a readable value.
+#[derive(Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ValueFormat {
+    Number,
+    Month,
+    DateTime,
+}
+
+#[derive(Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldDivergence {
+    pub key: String,
+    pub label: String,
+    pub comparison: ComparisonType,
+    pub format: ValueFormat,
+    /// How strongly the field's values separate the groups, [0,1]. `None` when
+    /// fewer than two groups have any present values.
+    pub value_score: Option<f64>,
+    /// How strongly field *presence* (vs absence) separates the groups, [0,1].
+    pub coverage_score: f64,
+    /// True when at least one group has too few present values to trust `value_score`.
+    pub low_confidence: bool,
+    /// Per-group summaries, in input group order.
+    pub groups: Vec<GroupSummary>,
+}
+
+/// Per-group summary for one field. Which fields are populated depends on the
+/// field's `comparison` type (the UI reads the relevant ones).
+#[derive(Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupSummary {
+    pub n: u32,
+    pub present: u32,
+    // Linear numeric
+    pub median: Option<f64>,
+    pub p25: Option<f64>,
+    pub p75: Option<f64>,
+    // Circular
+    pub mean_deg: Option<f64>,
+    pub concentration: Option<f64>,
+    // Categorical
+    pub top: Vec<TopValue>,
+}
+
+impl GroupSummary {
+    fn empty(n: u32, present: u32) -> Self {
+        GroupSummary { n, present, median: None, p25: None, p75: None, mean_deg: None, concentration: None, top: Vec::new() }
+    }
+}
+
+#[derive(Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TopValue {
+    pub label: String,
+    pub freq: f64,
+}
+
+/// Resolve N selections to labeled location groups and rank metadata fields by how
+/// strongly they separate the groups. Locations matched by more than one selection
+/// are dropped (ambiguous label) and counted in `excluded_overlap`. Errors with
+/// fewer than two selections.
+#[tauri::command]
+#[specta::specta]
+pub async fn store_disambiguate(
+    webview: tauri::Webview,
+    state: tauri::State<'_, StoreState>,
+    groups: Vec<SelectionInput>,
+    field_defs: HashMap<String, ExtraFieldDef>,
+) -> Result<DisambiguateResult, String> {
+    if groups.len() < 2 {
+        return Err("disambiguation needs at least 2 selections".into());
+    }
+    let _t = std::time::Instant::now();
+
+    let mut mgr = state.lock().map_err(|e| e.to_string())?;
+    let store = mgr.store_for_window(webview.label())?;
+    let tag_names: HashMap<u32, String> = store.tags.all.iter().map(|(id, t)| (*id, t.name.clone())).collect();
+
+    let view = store.loc_view();
+    let masks: Vec<Vec<bool>> = groups.iter().map(|g| resolve_bitmask(&view, &g.props)).collect();
+    let batch_rows = view.batch_rows();
+
+    let mut labeled: Vec<(usize, Location)> = Vec::new();
+    let mut excluded_overlap: u32 = 0;
+
+    for i in 0..batch_rows {
+        if !view.is_alive(i) {
+            continue;
+        }
+        match sole_group(&masks, i) {
+            Err(()) => excluded_overlap += 1,
+            Ok(Some(gi)) => labeled.push((gi, view.location_at_batch(i))),
+            Ok(None) => {}
+        }
+    }
+    for (j, loc) in view.adds().iter().enumerate() {
+        match sole_group(&masks, batch_rows + j) {
+            Err(()) => excluded_overlap += 1,
+            Ok(Some(gi)) => labeled.push((gi, loc.clone())),
+            Ok(None) => {}
+        }
+    }
+    drop(view);
+
+    let mut result = compute_divergence(&labeled, groups.len(), &field_defs, &tag_names);
+    result.excluded_overlap = excluded_overlap;
+
+    log::debug!("[cmd] store_disambiguate total={}ms groups={} labeled={} excluded_overlap={} fields={}",
+        _t.elapsed().as_millis(), groups.len(), labeled.len(), excluded_overlap, result.fields.len());
+
+    Ok(result)
+}
+
+/// Which single group a row belongs to: `Ok(Some(g))` for exactly one, `Ok(None)`
+/// for none, `Err(())` for more than one (ambiguous, excluded from analysis).
+fn sole_group(masks: &[Vec<bool>], row: usize) -> Result<Option<usize>, ()> {
+    let mut found: Option<usize> = None;
+    for (gi, m) in masks.iter().enumerate() {
+        if m[row] {
+            if found.is_some() {
+                return Err(());
+            }
+            found = Some(gi);
+        }
+    }
+    Ok(found)
+}
+
+/// Compute field divergence across labeled groups. `labeled` pairs a group index
+/// (0..num_groups) with a fully-materialized location. Pure and store-free so it
+/// can be unit-tested directly.
+pub fn compute_divergence(
+    labeled: &[(usize, Location)],
+    num_groups: usize,
+    field_defs: &HashMap<String, ExtraFieldDef>,
+    tag_names: &HashMap<u32, String>,
+) -> DisambiguateResult {
+    let mut group_sizes = vec![0u32; num_groups];
+    for (g, _) in labeled {
+        group_sizes[*g] += 1;
+    }
+
+    let mut fields: Vec<FieldDivergence> = Vec::new();
+
+    // Built-in numeric columns worth analyzing (lat/lng/timestamps intentionally excluded).
+    for key in ["heading", "pitch", "zoom"] {
+        let comparison = resolved_comparison(key, None);
+        fields.push(numeric_field(key, labeled, num_groups, &group_sizes, comparison, None));
+    }
+
+    // Extra fields: registered defs plus any key discovered on the locations.
+    let mut extra_keys: HashSet<String> = field_defs.keys().cloned().collect();
+    for (_, loc) in labeled {
+        if let Some(extra) = &loc.extra {
+            for k in extra.keys() {
+                extra_keys.insert(k.clone());
+            }
+        }
+    }
+    extra_keys.retain(|k| !EXCLUDED_FIELDS.contains(&k.as_str()));
+    let mut extra_keys: Vec<String> = extra_keys.into_iter().collect();
+    extra_keys.sort();
+    for key in &extra_keys {
+        // Effective def: the registered one, or inferred from a sample value so an
+        // undeclared numeric field isn't mistaken for categorical.
+        let inferred;
+        let def: Option<&ExtraFieldDef> = match field_defs.get(key) {
+            Some(d) => Some(d),
+            None => {
+                inferred = sample_def(key, labeled);
+                inferred.as_ref()
+            }
+        };
+        let comparison = resolved_comparison(key, def);
+        match comparison {
+            ComparisonType::Categorical => fields.push(categorical_field(key, labeled, num_groups, &group_sizes, def)),
+            _ => fields.push(numeric_field(key, labeled, num_groups, &group_sizes, comparison, def)),
+        }
+    }
+
+    // Tags as boolean categorical fields (always 100% coverage).
+    let mut tag_ids: HashSet<u32> = HashSet::new();
+    for (_, loc) in labeled {
+        for t in &loc.tags {
+            tag_ids.insert(*t);
+        }
+    }
+    let mut tag_ids: Vec<u32> = tag_ids.into_iter().collect();
+    tag_ids.sort_unstable();
+    for tid in tag_ids {
+        fields.push(tag_field(tid, labeled, num_groups, &group_sizes, tag_names));
+    }
+
+    // Rank: confident value scores first (desc), then low-confidence/none by coverage.
+    fields.sort_by(|a, b| sort_key(b).partial_cmp(&sort_key(a)).unwrap_or(std::cmp::Ordering::Equal));
+
+    DisambiguateResult { fields, excluded_overlap: 0, group_sizes }
+}
+
+/// Sort key: confident value score dominates; otherwise rank by coverage score
+/// (shifted below any confident value score).
+fn sort_key(f: &FieldDivergence) -> f64 {
+    match (f.value_score, f.low_confidence) {
+        (Some(v), false) => 1.0 + v,
+        _ => f.coverage_score,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field builders
+// ---------------------------------------------------------------------------
+
+fn numeric_field(
+    key: &str,
+    labeled: &[(usize, Location)],
+    num_groups: usize,
+    group_sizes: &[u32],
+    comparison: ComparisonType,
+    def: Option<&ExtraFieldDef>,
+) -> FieldDivergence {
+    // Per-group present numeric values.
+    let mut per_group: Vec<Vec<f64>> = vec![Vec::new(); num_groups];
+    for (g, loc) in labeled {
+        if let Some(v) = numeric_value(loc, key) {
+            per_group[*g].push(v);
+        }
+    }
+
+    let present: Vec<u32> = per_group.iter().map(|v| v.len() as u32).collect();
+    let value_score = match &comparison {
+        ComparisonType::Circular { period } => circular_eta2(&per_group, *period),
+        _ => kruskal_eps2(&per_group),
+    };
+    let coverage_score = coverage_v(group_sizes, &present);
+    let low_confidence = is_low_confidence(&present);
+
+    let groups: Vec<GroupSummary> = (0..num_groups)
+        .map(|g| {
+            let n = group_sizes[g];
+            let vals = &per_group[g];
+            let mut s = GroupSummary::empty(n, vals.len() as u32);
+            if !vals.is_empty() {
+                match &comparison {
+                    ComparisonType::Circular { period } => {
+                        let (mean_deg, conc) = circular_summary(vals, *period);
+                        s.mean_deg = Some(mean_deg);
+                        s.concentration = Some(conc);
+                    }
+                    _ => {
+                        let (p25, median, p75) = quartiles(vals);
+                        s.p25 = Some(p25);
+                        s.median = Some(median);
+                        s.p75 = Some(p75);
+                    }
+                }
+            }
+            s
+        })
+        .collect();
+
+    let format = match def.map(|d| &d.field_type) {
+        Some(ExtraFieldType::Month) => ValueFormat::Month,
+        Some(ExtraFieldType::Date) => ValueFormat::DateTime,
+        _ => ValueFormat::Number,
+    };
+    FieldDivergence { key: key.to_string(), label: field_label(key, def), comparison, format, value_score, coverage_score, low_confidence, groups }
+}
+
+/// Build a synthetic field def for an undeclared key by inferring its type from
+/// the first present value across the labeled locations.
+fn sample_def(key: &str, labeled: &[(usize, Location)]) -> Option<ExtraFieldDef> {
+    for (_, loc) in labeled {
+        if let Some(v) = loc.extra.as_ref().and_then(|e| e.get(key)) {
+            if !v.is_null() {
+                return Some(ExtraFieldDef {
+                    field_type: infer_field_type(v),
+                    label: None,
+                    values: None,
+                    labels: None,
+                    comparison: None,
+                });
+            }
+        }
+    }
+    None
+}
+
+fn categorical_field(
+    key: &str,
+    labeled: &[(usize, Location)],
+    num_groups: usize,
+    group_sizes: &[u32],
+    def: Option<&ExtraFieldDef>,
+) -> FieldDivergence {
+    let mut per_group: Vec<HashMap<String, u32>> = vec![HashMap::new(); num_groups];
+    for (g, loc) in labeled {
+        if let Some(v) = category_value(loc, key) {
+            *per_group[*g].entry(v).or_insert(0) += 1;
+        }
+    }
+    finish_categorical(key, field_label(key, def), per_group, num_groups, group_sizes, def)
+}
+
+fn tag_field(
+    tid: u32,
+    labeled: &[(usize, Location)],
+    num_groups: usize,
+    group_sizes: &[u32],
+    tag_names: &HashMap<u32, String>,
+) -> FieldDivergence {
+    let mut per_group: Vec<HashMap<String, u32>> = vec![HashMap::new(); num_groups];
+    for (g, loc) in labeled {
+        let has = loc.tags.contains(&tid);
+        *per_group[*g].entry(if has { "yes".into() } else { "no".into() }).or_insert(0) += 1;
+    }
+    let label = tag_names.get(&tid).cloned().unwrap_or_else(|| format!("Tag {tid}"));
+    finish_categorical(&format!("tag:{tid}"), label, per_group, num_groups, group_sizes, None)
+}
+
+fn finish_categorical(
+    key: &str,
+    label: String,
+    per_group: Vec<HashMap<String, u32>>,
+    num_groups: usize,
+    group_sizes: &[u32],
+    def: Option<&ExtraFieldDef>,
+) -> FieldDivergence {
+    let present: Vec<u32> = per_group.iter().map(|m| m.values().sum()).collect();
+    let value_score = cramers_v(&per_group);
+    let coverage_score = coverage_v(group_sizes, &present);
+    let low_confidence = is_low_confidence(&present);
+
+    let labels = def.and_then(|d| d.labels.as_ref());
+    let groups: Vec<GroupSummary> = (0..num_groups)
+        .map(|g| {
+            let counts = &per_group[g];
+            let total: u32 = counts.values().sum();
+            let mut s = GroupSummary::empty(group_sizes[g], total);
+            if total > 0 {
+                let mut pairs: Vec<(&String, &u32)> = counts.iter().collect();
+                pairs.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+                s.top = pairs.into_iter().take(TOP_N).map(|(val, c)| TopValue {
+                    label: labels.and_then(|l| l.get(val)).cloned().unwrap_or_else(|| val.clone()),
+                    freq: *c as f64 / total as f64,
+                }).collect();
+            }
+            s
+        })
+        .collect();
+
+    FieldDivergence { key: key.to_string(), label, comparison: ComparisonType::Categorical, format: ValueFormat::Number, value_score, coverage_score, low_confidence, groups }
+}
+
+// ---------------------------------------------------------------------------
+// Value extraction
+// ---------------------------------------------------------------------------
+
+fn numeric_value(loc: &Location, key: &str) -> Option<f64> {
+    match key {
+        "heading" => Some(loc.heading),
+        "pitch" => Some(loc.pitch),
+        "zoom" => Some(loc.zoom),
+        _ => {
+            let v = loc.extra.as_ref()?.get(key)?;
+            if let Some(n) = v.as_f64() {
+                return Some(n);
+            }
+            // String dates: ISO datetime -> unix seconds; "YYYY-MM" -> month index.
+            let s = v.as_str()?;
+            if let Some(ts) = iso_to_unix(s) {
+                return Some(ts);
+            }
+            parse_year_month(s)
+        }
+    }
+}
+
+fn parse_year_month(s: &str) -> Option<f64> {
+    let b = s.as_bytes();
+    if b.len() == 7 && b[4] == b'-'
+        && b[..4].iter().all(|c| c.is_ascii_digit())
+        && b[5..].iter().all(|c| c.is_ascii_digit())
+    {
+        let year: f64 = s[..4].parse().ok()?;
+        let month: f64 = s[5..].parse().ok()?;
+        return Some(year * 12.0 + (month - 1.0));
+    }
+    None
+}
+
+fn category_value(loc: &Location, key: &str) -> Option<String> {
+    let v = loc.extra.as_ref()?.get(key)?;
+    json_to_category(v)
+}
+
+/// Canonical string for a categorical JSON value (null/missing -> None).
+fn json_to_category(v: &serde_json::Value) -> Option<String> {
+    match v {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => Some(v.to_string()),
+    }
+}
+
+fn field_label(key: &str, def: Option<&ExtraFieldDef>) -> String {
+    if let Some(l) = def.and_then(|d| d.label.clone()) {
+        return l;
+    }
+    match key {
+        "heading" => "Heading".into(),
+        "pitch" => "Pitch".into(),
+        "zoom" => "Zoom".into(),
+        _ => known_field_def(key).and_then(|d| d.label).unwrap_or_else(|| key.to_string()),
+    }
+}
+
+fn is_low_confidence(present: &[u32]) -> bool {
+    present.iter().any(|&p| p < MIN_PRESENT)
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+/// Epsilon-squared effect size from the (tie-corrected) Kruskal-Wallis H statistic.
+/// Returns `None` if fewer than two groups have data. Range [0,1].
+fn kruskal_eps2(per_group: &[Vec<f64>]) -> Option<f64> {
+    let nonempty = per_group.iter().filter(|g| !g.is_empty()).count();
+    if nonempty < 2 {
+        return None;
+    }
+    // Flatten with group labels, then assign average ranks.
+    let mut all: Vec<(f64, usize)> = Vec::new();
+    for (g, vals) in per_group.iter().enumerate() {
+        for &v in vals {
+            all.push((v, g));
+        }
+    }
+    let n = all.len();
+    if n < 3 {
+        return Some(0.0);
+    }
+    all.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut rank_sums = vec![0.0f64; per_group.len()];
+    let mut tie_correction = 0.0f64; // sum of (t^3 - t)
+    let mut i = 0;
+    while i < n {
+        let mut j = i + 1;
+        while j < n && all[j].0 == all[i].0 {
+            j += 1;
+        }
+        let t = (j - i) as f64;
+        // Average rank for tied block (1-based ranks).
+        let avg_rank = (i + 1 + j) as f64 / 2.0;
+        for k in i..j {
+            rank_sums[all[k].1] += avg_rank;
+        }
+        tie_correction += t * t * t - t;
+        i = j;
+    }
+
+    let nf = n as f64;
+    let mut h = 0.0;
+    for (g, vals) in per_group.iter().enumerate() {
+        if vals.is_empty() {
+            continue;
+        }
+        h += rank_sums[g] * rank_sums[g] / vals.len() as f64;
+    }
+    h = 12.0 / (nf * (nf + 1.0)) * h - 3.0 * (nf + 1.0);
+
+    let denom = 1.0 - tie_correction / (nf * nf * nf - nf);
+    if denom > 0.0 {
+        h /= denom;
+    }
+    if h <= 0.0 {
+        return Some(0.0);
+    }
+
+    // epsilon-squared = H * (n + 1) / (n^2 - 1) = H / (n - 1)
+    let eps2 = h / (nf - 1.0);
+    Some(eps2.clamp(0.0, 1.0))
+}
+
+/// One-way circular ANOVA effect size. Each group's values are unit vectors at
+/// angle (value / period * 2pi). Returns the between-group share of concentration,
+/// clamped to [0,1]. `None` if fewer than two groups have data.
+fn circular_eta2(per_group: &[Vec<f64>], period: f64) -> Option<f64> {
+    let nonempty = per_group.iter().filter(|g| !g.is_empty()).count();
+    if nonempty < 2 || period == 0.0 {
+        return None;
+    }
+    let mut sum_r = 0.0; // sum of group resultant lengths
+    let mut total_c = 0.0;
+    let mut total_s = 0.0;
+    let mut n = 0.0;
+    for vals in per_group {
+        if vals.is_empty() {
+            continue;
+        }
+        let (c, s) = sincos_sums(vals, period);
+        sum_r += (c * c + s * s).sqrt();
+        total_c += c;
+        total_s += s;
+        n += vals.len() as f64;
+    }
+    let r = (total_c * total_c + total_s * total_s).sqrt();
+    let denom = n - r;
+    if denom <= 1e-9 {
+        return Some(0.0);
+    }
+    Some(((sum_r - r) / denom).clamp(0.0, 1.0))
+}
+
+fn sincos_sums(vals: &[f64], period: f64) -> (f64, f64) {
+    let mut c = 0.0;
+    let mut s = 0.0;
+    for &v in vals {
+        let theta = v / period * 2.0 * PI;
+        c += theta.cos();
+        s += theta.sin();
+    }
+    (c, s)
+}
+
+/// Mean angle (in original units, [0, period)) and concentration (resultant length
+/// / n, in [0,1]) for one group.
+fn circular_summary(vals: &[f64], period: f64) -> (f64, f64) {
+    let (c, s) = sincos_sums(vals, period);
+    let n = vals.len() as f64;
+    let mut theta = s.atan2(c); // [-pi, pi]
+    if theta < 0.0 {
+        theta += 2.0 * PI;
+    }
+    let mean = theta / (2.0 * PI) * period;
+    let conc = (c * c + s * s).sqrt() / n;
+    (mean, conc)
+}
+
+/// Bias-corrected Cramer's V over a groups-by-category contingency table.
+/// Returns `None` if fewer than two groups (or categories) have data. Range [0,1].
+fn cramers_v(per_group: &[HashMap<String, u32>]) -> Option<f64> {
+    let mut categories: HashSet<&String> = HashSet::new();
+    for m in per_group {
+        for k in m.keys() {
+            categories.insert(k);
+        }
+    }
+    let cats: Vec<&String> = categories.into_iter().collect();
+    let row_totals: Vec<f64> = per_group.iter().map(|m| m.values().sum::<u32>() as f64).collect();
+    let n: f64 = row_totals.iter().sum();
+    let nonempty_rows = row_totals.iter().filter(|&&r| r > 0.0).count();
+    if nonempty_rows < 2 || cats.len() < 2 || n < 1.0 {
+        return Some(0.0);
+    }
+    let col_totals: Vec<f64> = cats.iter().map(|c| {
+        per_group.iter().map(|m| *m.get(*c).unwrap_or(&0) as f64).sum()
+    }).collect();
+
+    let mut chi2 = 0.0;
+    for (gi, m) in per_group.iter().enumerate() {
+        if row_totals[gi] == 0.0 {
+            continue;
+        }
+        for (ci, cat) in cats.iter().enumerate() {
+            let observed = *m.get(*cat).unwrap_or(&0) as f64;
+            let expected = row_totals[gi] * col_totals[ci] / n;
+            if expected > 0.0 {
+                let d = observed - expected;
+                chi2 += d * d / expected;
+            }
+        }
+    }
+
+    let phi2 = chi2 / n;
+    let k = cats.len() as f64;
+    let r = nonempty_rows as f64;
+    // Bergsma bias correction.
+    let phi2_corr = (phi2 - (k - 1.0) * (r - 1.0) / (n - 1.0)).max(0.0);
+    let k_corr = k - (k - 1.0) * (k - 1.0) / (n - 1.0);
+    let r_corr = r - (r - 1.0) * (r - 1.0) / (n - 1.0);
+    let denom = (k_corr - 1.0).min(r_corr - 1.0);
+    if denom <= 0.0 {
+        return Some(0.0);
+    }
+    Some((phi2_corr / denom).sqrt().clamp(0.0, 1.0))
+}
+
+/// Coverage divergence: Cramer's V on a present/absent x group contingency table.
+fn coverage_v(group_sizes: &[u32], present: &[u32]) -> f64 {
+    let per_group: Vec<HashMap<String, u32>> = group_sizes.iter().zip(present).map(|(&n, &p)| {
+        let mut m = HashMap::new();
+        m.insert("present".to_string(), p);
+        m.insert("absent".to_string(), n.saturating_sub(p));
+        m
+    }).collect();
+    cramers_v(&per_group).unwrap_or(0.0)
+}
+
+// ---------------------------------------------------------------------------
+// Quartiles
+// ---------------------------------------------------------------------------
+
+fn quartiles(vals: &[f64]) -> (f64, f64, f64) {
+    let mut v = vals.to_vec();
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    (percentile(&v, 0.25), percentile(&v, 0.5), percentile(&v, 0.75))
+}
+
+/// Linear-interpolated percentile over an already-sorted slice.
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let pos = q * (sorted.len() - 1) as f64;
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    let frac = pos - lo as f64;
+    sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+}

--- a/app/src-tauri/src/disambiguate.test.rs
+++ b/app/src-tauri/src/disambiguate.test.rs
@@ -1,0 +1,221 @@
+//! Tests for the selection disambiguation engine. These exercise the pure
+//! `compute_divergence` path and the statistical/labeling helpers — no store needed.
+
+use super::*;
+use crate::map_meta::{ComparisonType, ExtraFieldDef, ExtraFieldType};
+use crate::types::Location;
+use serde_json::json;
+use std::collections::HashMap;
+
+fn loc(heading: f64, extra: serde_json::Value, tags: Vec<u32>) -> Location {
+    Location {
+        id: 0,
+        lat: 0.0,
+        lng: 0.0,
+        heading,
+        pitch: 0.0,
+        zoom: 0.0,
+        pano_id: None,
+        flags: 0,
+        tags,
+        extra: extra.as_object().cloned(),
+        created_at: String::new(),
+        modified_at: None,
+    }
+}
+
+fn number_def() -> ExtraFieldDef {
+    ExtraFieldDef { field_type: ExtraFieldType::Number, label: None, values: None, labels: None, comparison: None }
+}
+
+fn defs(pairs: &[(&str, ExtraFieldDef)]) -> HashMap<String, ExtraFieldDef> {
+    pairs.iter().map(|(k, d)| (k.to_string(), d.clone())).collect()
+}
+
+fn find<'a>(r: &'a DisambiguateResult, key: &str) -> &'a FieldDivergence {
+    r.fields.iter().find(|f| f.key == key).unwrap_or_else(|| panic!("field {key} not found"))
+}
+
+/// Build labeled locations: `groups[g]` is the list of locations for group g.
+fn labeled(groups: Vec<Vec<Location>>) -> Vec<(usize, Location)> {
+    let mut out = Vec::new();
+    for (g, locs) in groups.into_iter().enumerate() {
+        for l in locs {
+            out.push((g, l));
+        }
+    }
+    out
+}
+
+// --- Numeric (linear) -------------------------------------------------------
+
+#[test]
+fn separated_numeric_scores_high() {
+    let a: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": i as f64 }), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": 1000.0 + i as f64 }), vec![])).collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("alt", number_def())]), &HashMap::new());
+    let f = find(&r, "alt");
+    assert!(matches!(f.comparison, ComparisonType::Linear));
+    assert!(f.value_score.unwrap() > 0.8, "got {:?}", f.value_score);
+    assert!(!f.low_confidence);
+}
+
+#[test]
+fn overlapping_numeric_scores_low() {
+    let a: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": (i % 10) as f64 }), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": (i % 10) as f64 }), vec![])).collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("alt", number_def())]), &HashMap::new());
+    assert!(find(&r, "alt").value_score.unwrap() < 0.15);
+}
+
+#[test]
+fn ranking_puts_most_separating_field_first() {
+    // alt cleanly separates; noise is identical across groups.
+    let a: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": i as f64, "noise": (i % 3) as f64 }), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": 1000.0 + i as f64, "noise": (i % 3) as f64 }), vec![])).collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("alt", number_def()), ("noise", number_def())]), &HashMap::new());
+    assert_eq!(r.fields[0].key, "alt");
+}
+
+// --- Categorical ------------------------------------------------------------
+
+#[test]
+fn separated_categorical_scores_high() {
+    let a: Vec<Location> = (0..12).map(|_| loc(0.0, json!({ "cc": "US" }), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|_| loc(0.0, json!({ "cc": "FR" }), vec![])).collect();
+    let cc = ExtraFieldDef { field_type: ExtraFieldType::String, label: None, values: None, labels: None, comparison: None };
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("cc", cc)]), &HashMap::new());
+    let f = find(&r, "cc");
+    assert!(matches!(f.comparison, ComparisonType::Categorical));
+    assert!(f.value_score.unwrap() > 0.8, "got {:?}", f.value_score);
+}
+
+#[test]
+fn shared_dominant_value_scores_low() {
+    // Both groups are mostly "gen2" — a common modal value that does NOT separate them.
+    let mk = |_| loc(0.0, json!({ "cam": "gen2" }), vec![]);
+    let a: Vec<Location> = (0..12).map(mk).collect();
+    let b: Vec<Location> = (0..12).map(mk).collect();
+    let cam = ExtraFieldDef { field_type: ExtraFieldType::Enum, label: None, values: None, labels: None, comparison: None };
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("cam", cam)]), &HashMap::new());
+    assert!(find(&r, "cam").value_score.unwrap() < 0.15);
+}
+
+// --- Circular ---------------------------------------------------------------
+
+#[test]
+fn circular_treats_wraparound_as_close() {
+    // Group A ~350deg, group B ~10deg: only ~20deg apart across the 0/360 seam.
+    let a: Vec<Location> = (0..12).map(|i| loc(348.0 + (i % 5) as f64, json!({}), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|i| loc(8.0 + (i % 5) as f64, json!({}), vec![])).collect();
+    let lab = labeled(vec![a, b]);
+    let r = compute_divergence(&lab, 2, &HashMap::new(), &HashMap::new());
+    let f = find(&r, "heading");
+    assert!(matches!(f.comparison, ComparisonType::Circular { period } if period == 360.0));
+    let circular = f.value_score.unwrap();
+    assert!(circular < 0.3, "circular score should be low, got {circular}");
+
+    // A naive LINEAR metric on the same data would rank these as far apart.
+    let mut per_group = vec![Vec::new(), Vec::new()];
+    for (g, l) in &lab {
+        per_group[*g].push(l.heading);
+    }
+    let linear = kruskal_eps2(&per_group).unwrap();
+    assert!(linear > 0.7, "linear metric should be high (proves circular differs), got {linear}");
+}
+
+#[test]
+fn circular_opposite_directions_score_high() {
+    let a: Vec<Location> = (0..12).map(|i| loc((i % 5) as f64, json!({}), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|i| loc(178.0 + (i % 5) as f64, json!({}), vec![])).collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &HashMap::new(), &HashMap::new());
+    assert!(find(&r, "heading").value_score.unwrap() > 0.8);
+}
+
+// --- Coverage & missing data ------------------------------------------------
+
+#[test]
+fn coverage_asymmetry_is_flagged() {
+    // alt present in group A, entirely absent in group B.
+    let a: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "alt": i as f64 }), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|_| loc(0.0, json!({}), vec![])).collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("alt", number_def())]), &HashMap::new());
+    let f = find(&r, "alt");
+    assert!(f.coverage_score > 0.8, "coverage should be high, got {}", f.coverage_score);
+    // Only one group has values -> no value comparison possible.
+    assert!(f.value_score.is_none());
+}
+
+#[test]
+fn missing_values_not_treated_as_zero() {
+    // Both groups share the same present value (5); group B is mostly absent.
+    // If absent were treated as 0, B would look very different -> high score (WRONG).
+    let a: Vec<Location> = (0..12).map(|_| loc(0.0, json!({ "alt": 5.0 }), vec![])).collect();
+    let mut b: Vec<Location> = (0..3).map(|_| loc(0.0, json!({ "alt": 5.0 }), vec![])).collect();
+    b.extend((0..9).map(|_| loc(0.0, json!({}), vec![])));
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &defs(&[("alt", number_def())]), &HashMap::new());
+    let f = find(&r, "alt");
+    assert!(f.value_score.unwrap() < 0.15, "shared present value must not fabricate separation, got {:?}", f.value_score);
+    assert!(f.low_confidence, "group B has < MIN_PRESENT present values");
+    assert!(f.coverage_score > 0.5, "coverage difference IS the real signal here");
+}
+
+// --- Tags -------------------------------------------------------------------
+
+#[test]
+fn discriminating_tag_scores_high() {
+    let a: Vec<Location> = (0..12).map(|_| loc(0.0, json!({}), vec![7])).collect();
+    let b: Vec<Location> = (0..12).map(|_| loc(0.0, json!({}), vec![])).collect();
+    let names: HashMap<u32, String> = [(7u32, "Verified".to_string())].into_iter().collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &HashMap::new(), &names);
+    let f = find(&r, "tag:7");
+    assert_eq!(f.label, "Verified");
+    assert!(f.value_score.unwrap() > 0.8);
+    // Tags are always present -> no coverage asymmetry.
+    assert!(f.coverage_score < 1e-9);
+}
+
+// --- Excluded fields & labeling ---------------------------------------------
+
+#[test]
+fn spatial_and_timestamp_fields_never_analyzed() {
+    let a = vec![loc(0.0, json!({}), vec![]); 4];
+    let b = vec![loc(0.0, json!({}), vec![]); 4];
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &HashMap::new(), &HashMap::new());
+    for bad in ["lat", "lng", "createdAt", "modifiedAt"] {
+        assert!(!r.fields.iter().any(|f| f.key == bad), "{bad} must not be analyzed");
+    }
+}
+
+#[test]
+fn group_sizes_reflect_labels() {
+    let a = vec![loc(0.0, json!({}), vec![]); 5];
+    let b = vec![loc(0.0, json!({}), vec![]); 3];
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &HashMap::new(), &HashMap::new());
+    assert_eq!(r.group_sizes, vec![5, 3]);
+}
+
+#[test]
+fn sole_group_detects_overlap() {
+    // row 0: only group 0; row 1: groups 0 and 1 (overlap); row 2: none.
+    let masks = vec![
+        vec![true, true, false],
+        vec![false, true, false],
+    ];
+    assert_eq!(sole_group(&masks, 0), Ok(Some(0)));
+    assert_eq!(sole_group(&masks, 1), Err(()));
+    assert_eq!(sole_group(&masks, 2), Ok(None));
+}
+
+// --- Undeclared field inference ---------------------------------------------
+
+#[test]
+fn undeclared_numeric_field_treated_as_linear() {
+    // No field def passed; values are numbers -> must be inferred Linear, not Categorical.
+    let a: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "mystery": i as f64 }), vec![])).collect();
+    let b: Vec<Location> = (0..12).map(|i| loc(0.0, json!({ "mystery": 1000.0 + i as f64 }), vec![])).collect();
+    let r = compute_divergence(&labeled(vec![a, b]), 2, &HashMap::new(), &HashMap::new());
+    let f = find(&r, "mystery");
+    assert!(matches!(f.comparison, ComparisonType::Linear));
+    assert!(f.value_score.unwrap() > 0.8);
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod borders;
 mod geocoder;
 mod seen;
 mod vcs;
+mod disambiguate;
 
 /// Write arbitrary text content to a named temp file (`mma_{name}`). Returns the path.
 /// Used by JS to pass large payloads via file instead of IPC serialization.
@@ -448,6 +449,7 @@ pub fn run() {
                     location_store::store_sync_selections,
                     location_store::store_get_selected_ids_list,
                     location_store::store_resolve_selection,
+                    disambiguate::store_disambiguate,
                     // --- Render ---
                     location_store::store_fill_render_file,
                     location_store::store_resolve_pick,

--- a/app/src-tauri/src/location_store.rs
+++ b/app/src-tauri/src/location_store.rs
@@ -812,7 +812,7 @@ impl Store {
     }
 
     /// Construct a read-only view over all alive locations for selection resolution.
-    fn loc_view(&self) -> selections::LocView<'_> {
+    pub(crate) fn loc_view(&self) -> selections::LocView<'_> {
         selections::LocView::new(
             self.batch.as_ref(),
             &self.overlay.dead,

--- a/app/src-tauri/src/map_meta.rs
+++ b/app/src-tauri/src/map_meta.rs
@@ -79,6 +79,18 @@ pub enum ExtraFieldType {
     Enum,
 }
 
+/// How a field's values are compared when measuring how strongly it separates
+/// groups (see `disambiguate`). The only un-inferrable property a field can
+/// declare is circularity (heading/azimuth=360, hour-of-day=24, month=12);
+/// everything else is inferred from `ExtraFieldType`.
+#[derive(Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ComparisonType {
+    Linear,
+    Circular { period: f64 },
+    Categorical,
+}
+
 /// Schema definition for a single `Location.extra` field. Stored in the map's
 /// `extra.fields` JSON. For enum types, `values` lists valid options and `labels`
 /// provides display names.
@@ -93,6 +105,10 @@ pub struct ExtraFieldDef {
     pub values: Option<Vec<String>>,
     #[serde(default)]
     pub labels: Option<HashMap<String, String>>,
+    /// Optional override for how this field is compared during disambiguation.
+    /// `None` => inferred from `field_type` (see [`resolved_comparison`]).
+    #[serde(default)]
+    pub comparison: Option<ComparisonType>,
 }
 
 /// Top-level `extra` JSON blob on a map row. Currently only holds field definitions,
@@ -133,12 +149,14 @@ pub fn known_field_def(key: &str) -> Option<ExtraFieldDef> {
             label: Some("Altitude".into()),
             values: None,
             labels: None,
+            comparison: None,
         }),
         "countryCode" => Some(ExtraFieldDef {
             field_type: ExtraFieldType::String,
             label: Some("Country code".into()),
             values: None,
             labels: None,
+            comparison: None,
         }),
         "cameraType" => Some(ExtraFieldDef {
             field_type: ExtraFieldType::Enum,
@@ -146,6 +164,7 @@ pub fn known_field_def(key: &str) -> Option<ExtraFieldDef> {
             values: Some(vec!["gen1".into(), "gen2".into(), "gen4".into(), "badcam".into(), "tripod".into()]),
             labels: Some([("gen1", "Gen 1"), ("gen2", "Gen 2/3"), ("gen4", "Gen 4"), ("badcam", "Bad cam"), ("tripod", "Tripod")]
                 .into_iter().map(|(k, v)| (k.into(), v.into())).collect()),
+            comparison: None,
         }),
         "panoType" => Some(ExtraFieldDef {
             field_type: ExtraFieldType::Enum,
@@ -153,26 +172,51 @@ pub fn known_field_def(key: &str) -> Option<ExtraFieldDef> {
             values: Some(vec!["2".into(), "3".into(), "10".into()]),
             labels: Some([("2", "Official"), ("3", "Unknown"), ("10", "User uploaded")]
                 .into_iter().map(|(k, v)| (k.into(), v.into())).collect()),
+            comparison: None,
         }),
         "imageDate" => Some(ExtraFieldDef {
             field_type: ExtraFieldType::Month,
             label: Some("Image date".into()),
             values: None,
             labels: None,
+            comparison: None,
         }),
         "datetime" => Some(ExtraFieldDef {
             field_type: ExtraFieldType::Date,
             label: Some("Exact date".into()),
             values: None,
             labels: None,
+            comparison: None,
         }),
         "timezone" => Some(ExtraFieldDef {
             field_type: ExtraFieldType::Enum,
             label: Some("Timezone".into()),
             values: None,
             labels: None,
+            comparison: None,
         }),
         _ => None,
+    }
+}
+
+/// Resolve how a field should be compared during disambiguation. An explicit
+/// `comparison` on the field def wins; otherwise it's inferred. Built-in numeric
+/// columns are resolved by key (`heading` is circular over 360 degrees).
+pub fn resolved_comparison(key: &str, def: Option<&ExtraFieldDef>) -> ComparisonType {
+    if let Some(c) = def.and_then(|d| d.comparison.clone()) {
+        return c;
+    }
+    match key {
+        "heading" => return ComparisonType::Circular { period: 360.0 },
+        "pitch" | "zoom" => return ComparisonType::Linear,
+        _ => {}
+    }
+    match def.map(|d| &d.field_type) {
+        Some(ExtraFieldType::Number) | Some(ExtraFieldType::Date) | Some(ExtraFieldType::Month) => {
+            ComparisonType::Linear
+        }
+        Some(ExtraFieldType::String) | Some(ExtraFieldType::Enum) => ComparisonType::Categorical,
+        None => ComparisonType::Categorical,
     }
 }
 
@@ -212,6 +256,7 @@ pub fn auto_register_field_defs(
                 label: None,
                 values: None,
                 labels: None,
+                comparison: None,
             });
             new_defs.insert(key.clone(), def);
         }

--- a/app/src-tauri/src/selections.rs
+++ b/app/src-tauri/src/selections.rs
@@ -143,6 +143,13 @@ impl<'a> LocView<'a> {
         self.patches.get(&self.batch_id(i))
     }
 
+    /// Materialize the effective `Location` at batch row `i` (patch wins over the
+    /// underlying Arrow row). Used by cold-path analysis that needs full records.
+    pub fn location_at_batch(&self, i: usize) -> Location {
+        if let Some(p) = self.patch_at(i) { return p.clone(); }
+        crate::arrow_bridge::row_to_location(self.batch.unwrap(), i)
+    }
+
     /// Read the effective ID at batch row `i`, checking patches first.
     pub fn id_at(&self, i: usize) -> u32 {
         if self.has_patches {

--- a/app/src/bindings.gen.ts
+++ b/app/src/bindings.gen.ts
@@ -66,16 +66,16 @@ export const commands = {
 	/**  Lightweight status query: location count, version, and dirty flag. */
 	storeGetSummary: () => typedError<SummaryResult, string>(__TAURI_INVOKE("store_get_summary")),
 	/**  Return metadata for every map in the database. */
-	storeListMaps: () => typedError<MapMeta[], string>(__TAURI_INVOKE("store_list_maps")),
+	storeListMaps: () => typedError<MapMeta[], string>(__TAURI_INVOKE("store_list_maps")).then((v) => ((v.status === "ok" ? { ...v, data: v.data.map(i=>({...i,extra:({...i.extra,fields:i.extra.fields==null?i.extra.fields:Object.fromEntries(Object.entries(i.extra.fields).map(([k,v])=>[k,({...v,comparison:v.comparison==null?v.comparison:v.comparison})]))})})) } : v) as typeof v)),
 	/**  Fetch a single map's metadata by ID. Returns `None` if not found. */
 	storeGetMap: (id: string) => typedError<{
 	meta: MapMeta,
-} | null, string>(__TAURI_INVOKE("store_get_map", { id })),
+} | null, string>(__TAURI_INVOKE("store_get_map", { id })).then((v) => ((v.status === "ok" ? { ...v, data: v.data==null?v.data:({...v.data,meta:({...v.data.meta,extra:({...v.data.meta.extra,fields:v.data.meta.extra.fields==null?v.data.meta.extra.fields:Object.fromEntries(Object.entries(v.data.meta.extra.fields).map(([k,v])=>[k,({...v,comparison:v.comparison==null?v.comparison:v.comparison})]))})})}) } : v) as typeof v)),
 	/**
 	 *  Create a new empty map with default settings. Returns the full metadata
 	 *  (including the generated UUID) so the frontend can navigate to it immediately.
 	 */
-	storeCreateMap: (name: string, folder: string | null) => typedError<MapData, string>(__TAURI_INVOKE("store_create_map", { name, folder })),
+	storeCreateMap: (name: string, folder: string | null) => typedError<MapData, string>(__TAURI_INVOKE("store_create_map", { name, folder })).then((v) => ((v.status === "ok" ? { ...v, data: ({...v.data,meta:({...v.data.meta,extra:({...v.data.meta.extra,fields:v.data.meta.extra.fields==null?v.data.meta.extra.fields:Object.fromEntries(Object.entries(v.data.meta.extra.fields).map(([k,v])=>[k,({...v,comparison:v.comparison==null?v.comparison:v.comparison})]))})})}) } : v) as typeof v)),
 	/**
 	 *  Delete a map and all associated data: SQLite rows (maps, edit_history,
 	 *  commits, orphaned commit_trees) and Arrow IPC files on disk.
@@ -87,7 +87,7 @@ export const commands = {
 	 *  on the in-memory store when extra fields change, so auto-registration
 	 *  doesn't re-discover fields the user explicitly defined.
 	 */
-	storeUpdateMapMeta: (id: string, patch: MapMetaPatch_Deserialize) => typedError<null, string>(__TAURI_INVOKE("store_update_map_meta", { id, patch: ({...patch,scoreBounds:patch.scoreBounds==null?patch.scoreBounds:patch.scoreBounds}) })),
+	storeUpdateMapMeta: (id: string, patch: MapMetaPatch_Deserialize) => typedError<null, string>(__TAURI_INVOKE("store_update_map_meta", { id, patch: ({...patch,scoreBounds:patch.scoreBounds==null?patch.scoreBounds:patch.scoreBounds,extra:patch.extra==null?patch.extra:({...patch.extra,fields:patch.extra.fields==null?patch.extra.fields:Object.fromEntries(Object.entries(patch.extra.fields).map(([k,v])=>[k,({...v,comparison:v.comparison==null?v.comparison:v.comparison})]))})}) })),
 	/**
 	 *  Update `last_opened_at` to the current timestamp. Used to sort the map
 	 *  list by recency in the dashboard.
@@ -211,6 +211,13 @@ export const commands = {
 	 *  Used by plugins and one-off queries (e.g., tag merge, export filtered).
 	 */
 	storeResolveSelection: (props: SelectionProps) => typedError<number[], string>(__TAURI_INVOKE("store_resolve_selection", { props })),
+	/**
+	 *  Resolve N selections to labeled location groups and rank metadata fields by how
+	 *  strongly they separate the groups. Locations matched by more than one selection
+	 *  are dropped (ambiguous label) and counted in `excluded_overlap`. Errors with
+	 *  fewer than two selections.
+	 */
+	storeDisambiguate: (groups: SelectionInput[], fieldDefs: { [key in string]: ExtraFieldDef }) => typedError<DisambiguateResult, string>(__TAURI_INVOKE("store_disambiguate", { groups, fieldDefs: Object.fromEntries(Object.entries(fieldDefs).map(([k,v])=>[k,({...v,comparison:v.comparison==null?v.comparison:v.comparison})])) })).then((v) => ((v.status === "ok" ? { ...v, data: ({...v.data,fields:v.data.fields.map(i=>({...i,valueScore:i.valueScore==null?i.valueScore:i.valueScore,groups:i.groups.map(i=>({...i,median:i.median==null?i.median:i.median,p25:i.p25==null?i.p25:i.p25,p75:i.p75==null?i.p75:i.p75,meanDeg:i.meanDeg==null?i.meanDeg:i.meanDeg,concentration:i.concentration==null?i.concentration:i.concentration,top:i.top.map(i=>i)}))}))}) } : v) as typeof v)),
 	/**
 	 *  Full render rebuild: single-pass over all alive locations, writes binary to a temp file.
 	 *  Returns the file path for JS to fetch via `mma-buf://`. Only called on map open or full reset.
@@ -395,6 +402,14 @@ export type CommitInfo = {
 	createdAt: string,
 };
 
+/**
+ *  How a field's values are compared when measuring how strongly it separates
+ *  groups (see `disambiguate`). The only un-inferrable property a field can
+ *  declare is circularity (heading/azimuth=360, hour-of-day=24, month=12);
+ *  everything else is inferred from `ExtraFieldType`.
+ */
+export type ComparisonType = { type: "linear" } | { type: "circular"; period: number } | { type: "categorical" };
+
 /**  Aggregate database statistics for the debug panel. */
 export type DbStats = {
 	maps: number,
@@ -410,6 +425,15 @@ export type DbStats = {
 export type DbTableInfo = {
 	name: string,
 	rows: number,
+};
+
+export type DisambiguateResult = {
+	/**  Fields ranked by divergence (most separating first). */
+	fields: FieldDivergence[],
+	/**  Locations dropped because they belonged to more than one group. */
+	excludedOverlap: number,
+	/**  Per-group labeled location count (after overlap removal), input order. */
+	groupSizes: number[],
 };
 
 /**
@@ -479,6 +503,11 @@ export type ExtraFieldDef = {
 	label?: string | null,
 	values?: string[] | null,
 	labels?: { [key in string]: string } | null,
+	/**
+	 *  Optional override for how this field is compared during disambiguation.
+	 *  `None` => inferred from `field_type` (see [`resolved_comparison`]).
+	 */
+	comparison?: ComparisonType | null,
 };
 
 /**
@@ -496,6 +525,24 @@ export type FieldCount = {
 	count: number,
 };
 
+export type FieldDivergence = {
+	key: string,
+	label: string,
+	comparison: ComparisonType,
+	format: ValueFormat,
+	/**
+	 *  How strongly the field's values separate the groups, [0,1]. `None` when
+	 *  fewer than two groups have any present values.
+	 */
+	valueScore: number | null,
+	/**  How strongly field *presence* (vs absence) separates the groups, [0,1]. */
+	coverageScore: number,
+	/**  True when at least one group has too few present values to trust `value_score`. */
+	lowConfidence: boolean,
+	/**  Per-group summaries, in input group order. */
+	groups: GroupSummary[],
+};
+
 /**  Reverse geocode result: nearest populated place to a coordinate. */
 export type GeoResult = {
 	city: string,
@@ -504,6 +551,21 @@ export type GeoResult = {
 	country: string,
 	/**  ISO 3166-1 alpha-2 (e.g. "US", "FR"). */
 	country_code: string,
+};
+
+/**
+ *  Per-group summary for one field. Which fields are populated depends on the
+ *  field's `comparison` type (the UI reads the relevant ones).
+ */
+export type GroupSummary = {
+	n: number,
+	present: number,
+	median: number | null,
+	p25: number | null,
+	p75: number | null,
+	meanDeg: number | null,
+	concentration: number | null,
+	top: TopValue[],
 };
 
 /**
@@ -1012,6 +1074,18 @@ export type Tag = {
 	 */
 	count?: number,
 };
+
+export type TopValue = {
+	label: string,
+	freq: number,
+};
+
+/**
+ *  How the numeric per-group summaries should be rendered. Numeric fields are
+ *  compared as plain numbers internally even when they're dates, so the UI needs
+ *  this to turn a month-index or unix timestamp back into a readable value.
+ */
+export type ValueFormat = "number" | "month" | "dateTime";
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {

--- a/app/src/components/dialogs/DisambiguateDialog.add.tsx
+++ b/app/src/components/dialogs/DisambiguateDialog.add.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Dialog, DialogContent } from "@/components/primitives/Dialog";
+import { cmd } from "@/lib/commands";
+import { getSelectionInputs, useSelections } from "@/store/useMapStore";
+import { getAllFieldDefs } from "@/lib/data/fieldDefRegistry";
+import { log } from "@/lib/util/log";
+import type { DisambiguateResult, FieldDivergence, GroupSummary, ValueFormat, ExtraFieldDef } from "@/bindings.gen";
+
+interface Props {
+	onClose: () => void;
+}
+
+const GROUP_PALETTE = "abcdefghijklmnop";
+
+function rgb(c: [number, number, number]) {
+	return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}
+
+function badgeText(field: FieldDivergence): string {
+	if (field.format === "month") return "Month";
+	if (field.format === "dateTime") return "Date";
+	const c = field.comparison;
+	if (c.type === "circular") return `Circular ${Math.round(c.period)}`;
+	if (c.type === "linear") return "Numeric";
+	return "Categorical";
+}
+
+function fmtNum(n: number | null | undefined): string {
+	if (n === null || n === undefined || Number.isNaN(n)) return "-";
+	return Math.abs(n) >= 1000 || Number.isInteger(n) ? n.toFixed(0) : n.toFixed(2);
+}
+
+/** Format a numeric summary value back into a readable form for its field type. */
+function fmtVal(n: number | null | undefined, format: ValueFormat): string {
+	if (n === null || n === undefined || Number.isNaN(n)) return "-";
+	if (format === "month") {
+		const idx = Math.round(n);
+		const year = Math.floor(idx / 12);
+		const month = idx - year * 12 + 1;
+		return `${year}-${String(month).padStart(2, "0")}`;
+	}
+	if (format === "dateTime") {
+		return new Date(n * 1000).toISOString().slice(0, 10);
+	}
+	return fmtNum(n);
+}
+
+function GroupCell({ field, g, color }: { field: FieldDivergence; g: GroupSummary; color: [number, number, number] }) {
+	const coverage = g.n > 0 ? Math.round((g.present / g.n) * 100) : 0;
+	let body: ReactNode;
+	if (field.comparison.type === "circular") {
+		body = g.present > 0
+			? <span>{fmtNum(g.meanDeg)}&deg; <span className="disambig__muted">(conc {g.concentration?.toFixed(2)})</span></span>
+			: <span className="disambig__muted">no data</span>;
+	} else if (field.comparison.type === "categorical") {
+		body = g.top.length > 0
+			? <span>{g.top.map((t) => `${t.label} ${Math.round(t.freq * 100)}%`).join(", ")}</span>
+			: <span className="disambig__muted">no data</span>;
+	} else {
+		body = g.present > 0
+			? <span>{fmtVal(g.median, field.format)} <span className="disambig__muted">[{fmtVal(g.p25, field.format)}&ndash;{fmtVal(g.p75, field.format)}]</span></span>
+			: <span className="disambig__muted">no data</span>;
+	}
+	return (
+		<div className="disambig__group">
+			<span className="disambig__swatch" style={{ background: rgb(color) }} />
+			<div className="disambig__group-body">
+				{body}
+				<div className="disambig__muted disambig__coverage">{g.present}/{g.n} ({coverage}%)</div>
+			</div>
+		</div>
+	);
+}
+
+function FieldRow({ field, colors }: { field: FieldDivergence; colors: [number, number, number][] }) {
+	const score = field.valueScore;
+	return (
+		<div className={`disambig__row${field.lowConfidence ? " disambig__row--weak" : ""}`}>
+			<div className="disambig__head">
+				<span className="disambig__label">{field.label}</span>
+				<span className="disambig__badge">{badgeText(field)}</span>
+				{field.lowConfidence && <span className="disambig__badge disambig__badge--warn">low data</span>}
+				<span className="disambig__score">{score !== null ? score.toFixed(2) : "-"}</span>
+			</div>
+			<div className="disambig__bar">
+				<div className="disambig__bar-fill" style={{ width: `${(score ?? 0) * 100}%` }} />
+			</div>
+			{field.coverageScore > 0.01 && (
+				<div className="disambig__muted">presence differs across groups (coverage {field.coverageScore.toFixed(2)})</div>
+			)}
+			<div className="disambig__groups">
+				{field.groups.map((g, i) => (
+					<GroupCell key={i} field={field} g={g} color={colors[i] ?? [128, 128, 128]} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+export function DisambiguateDialog({ onClose }: Props) {
+	const selections = useSelections();
+	const [result, setResult] = useState<DisambiguateResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const colors = getSelectionInputs().map((s) => s.color);
+
+	useEffect(() => {
+		const groups = getSelectionInputs();
+		if (groups.length < 2) {
+			setError("Select at least 2 groups to disambiguate.");
+			return;
+		}
+		const fieldDefs: Record<string, ExtraFieldDef> = getAllFieldDefs();
+		setError(null);
+		cmd.storeDisambiguate(groups, fieldDefs)
+			.then(setResult)
+			.catch((e) => {
+				log.error("[disambiguate] failed:", e);
+				setError(String(e));
+			});
+	}, [selections]);
+
+	return (
+		<Dialog open onOpenChange={(open) => !open && onClose()}>
+			<DialogContent title="Disambiguate selections" className="disambig-modal">
+				{error && <div className="disambig__error">{error}</div>}
+				{!error && !result && <div className="disambig__muted">Analyzing&hellip;</div>}
+				{result && (
+					<>
+						<div className="disambig__summary disambig__muted">
+							{result.groupSizes.map((n, i) => (
+								<span key={i} className="disambig__group">
+									<span className="disambig__swatch" style={{ background: rgb(colors[i] ?? [128, 128, 128]) }} />
+									{n}
+								</span>
+							))}
+							{result.excludedOverlap > 0 && <span>&middot; {result.excludedOverlap} excluded (in multiple groups)</span>}
+						</div>
+						<div className="disambig__list">
+							{result.fields.map((f) => (
+								<FieldRow key={f.key} field={f} colors={colors} />
+							))}
+						</div>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/src/components/dialogs/ManageFieldsModal.add.tsx
+++ b/app/src/components/dialogs/ManageFieldsModal.add.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Dialog, DialogContent } from "@/components/primitives/Dialog";
 import { setMapExtraFields, getKnownFieldKeys } from "@/store/useMapStore";
 import type { ExtraFieldDef } from "@/types";
+import type { ComparisonType } from "@/bindings.gen";
 import { getFieldDef, getAllFieldDefs } from "@/lib/data/fieldDefRegistry";
 const FIELD_TYPES: ExtraFieldDef["type"][] = ["string", "number", "date", "month", "enum"];
 const TYPE_LABELS: Record<ExtraFieldDef["type"], string> = {
@@ -12,10 +13,35 @@ const TYPE_LABELS: Record<ExtraFieldDef["type"], string> = {
 	enum: "Enum",
 };
 
+// How a field is compared during disambiguation. "auto" = inferred from type.
+type CompToken = "auto" | "linear" | "circular" | "categorical";
+const COMP_OPTIONS: { token: CompToken; label: string }[] = [
+	{ token: "auto", label: "Auto" },
+	{ token: "linear", label: "Numeric" },
+	{ token: "circular", label: "Circular" },
+	{ token: "categorical", label: "Categorical" },
+];
+const DEFAULT_PERIOD = 360;
+
+function compToToken(c: ComparisonType | null | undefined): CompToken {
+	if (!c) return "auto";
+	return c.type;
+}
+
+function tokenToComp(t: CompToken, period: number): ComparisonType | undefined {
+	switch (t) {
+		case "auto": return undefined;
+		case "linear": return { type: "linear" };
+		case "categorical": return { type: "categorical" };
+		case "circular": return { type: "circular", period };
+	}
+}
+
 interface FieldRow {
 	key: string;
 	label: string;
 	type: ExtraFieldDef["type"];
+	comparison: ComparisonType | null;
 	hasData: boolean;
 }
 
@@ -32,6 +58,7 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 			key,
 			label: def?.label ?? key,
 			type: def?.type ?? "string",
+			comparison: def?.comparison ?? null,
 			hasData: knownKeys.has(key),
 		};
 	});
@@ -49,6 +76,7 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 			const existing = getFieldDef(row.key);
 			if (existing?.values) entry.values = existing.values;
 			if (existing?.labels) entry.labels = existing.labels;
+			if (row.comparison) entry.comparison = row.comparison;
 			fields[row.key] = entry;
 		}
 		await setMapExtraFields(fields);
@@ -72,6 +100,7 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 								<th>Field</th>
 								<th>Label</th>
 								<th>Type</th>
+								<th>Compare as</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -104,6 +133,37 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 												</option>
 											))}
 										</select>
+									</td>
+									<td>
+										<select
+											className="nselect"
+											value={compToToken(row.comparison)}
+											onChange={(e) =>
+												updateRow(row.key, { comparison: tokenToComp(e.target.value as CompToken, row.comparison?.type === "circular" ? row.comparison.period : DEFAULT_PERIOD) ?? null })
+											}
+										>
+											{COMP_OPTIONS.map((o) => (
+												<option key={o.token} value={o.token}>
+													{o.label}
+												</option>
+											))}
+										</select>
+										{row.comparison?.type === "circular" && (
+											<input
+												className="input manage-fields-table__period"
+												type="number"
+												min="0"
+												step="any"
+												value={row.comparison.period}
+												title="Value at which the field wraps around (e.g. 360 for degrees, 24 for hours, 12 for months)"
+												onChange={(e) => {
+													const period = parseFloat(e.target.value);
+													updateRow(row.key, {
+														comparison: { type: "circular", period: Number.isFinite(period) ? period : DEFAULT_PERIOD },
+													});
+												}}
+											/>
+										)}
 									</td>
 								</tr>
 							))}

--- a/app/src/components/editor/map/MapMetaBar.tsx
+++ b/app/src/components/editor/map/MapMetaBar.tsx
@@ -12,6 +12,7 @@ import { ExportDialog } from "@/components/dialogs/ExportDialog";
 import { ImportDialog } from "@/components/dialogs/ImportDialog";
 import { VersionHistory } from "@/components/dialogs/VersionHistory.add";
 import { SeenDialog } from "@/components/dialogs/SeenDialog.add";
+import { DisambiguateDialog } from "@/components/dialogs/DisambiguateDialog.add";
 import { loadSeenPano } from "@/components/editor/location/LocationPreview";
 import { Icon } from "@/components/primitives/Icon";
 import { mdiUndo, mdiRedo } from "@mdi/js";
@@ -26,21 +27,25 @@ export function MapMetaBar() {
 	const [showImport, setShowImport] = useState(false);
 	const [showHistory, setShowHistory] = useState(false);
 	const [showSeen, setShowSeen] = useState(false);
+	const [showDisambiguate, setShowDisambiguate] = useState(false);
 
 	useEffect(() => {
 		const onExport = () => setShowExport(true);
 		const onImport = () => setShowImport(true);
 		const onHistory = () => setShowHistory(true);
 		const onSeen = () => setShowSeen(true);
+		const onDisambiguate = () => setShowDisambiguate(true);
 		document.addEventListener("open-export", onExport);
 		document.addEventListener("open-import", onImport);
 		document.addEventListener("open-history", onHistory);
 		document.addEventListener("open-seen", onSeen);
+		document.addEventListener("open-disambiguate", onDisambiguate);
 		return () => {
 			document.removeEventListener("open-export", onExport);
 			document.removeEventListener("open-import", onImport);
 			document.removeEventListener("open-history", onHistory);
 			document.removeEventListener("open-seen", onSeen);
+			document.removeEventListener("open-disambiguate", onDisambiguate);
 		};
 	}, []);
 
@@ -109,6 +114,7 @@ export function MapMetaBar() {
 			{showExport && <ExportDialog onClose={() => setShowExport(false)} />}
 			{showHistory && <VersionHistory onClose={() => setShowHistory(false)} />}
 			<SeenDialog open={showSeen} onOpenChange={setShowSeen} onLoadPano={loadSeenPano} />
+			{showDisambiguate && <DisambiguateDialog onClose={() => setShowDisambiguate(false)} />}
 		</>
 	);
 }

--- a/app/src/store/commandDefs.add.ts
+++ b/app/src/store/commandDefs.add.ts
@@ -18,6 +18,7 @@ import {
 	mdiTagRemove,
 	mdiDatabaseRemoveOutline,
 	mdiFindReplace,
+	mdiCompare,
 } from "@mdi/js";
 import { registerCommand } from "./commands.add";
 import {
@@ -79,6 +80,15 @@ registerCommand({
 	defaultBinding: "Mod+y, Mod+Shift+z",
 	execute: redo,
 	enabled: () => getUndoRedoState().canRedo,
+});
+
+registerCommand({
+	id: "disambiguate",
+	label: "Disambiguate selections",
+	icon: mdiCompare,
+	group: "Selections",
+	execute: () => document.dispatchEvent(new CustomEvent("open-disambiguate")),
+	enabled: () => getSelections().length >= 2,
 });
 
 registerCommand({

--- a/app/src/store/useMapStore.ts
+++ b/app/src/store/useMapStore.ts
@@ -675,12 +675,9 @@ export function useSelections() {
 	return selections;
 }
 
-/** Apply a pure selection transform, then IPC to Rust to resolve bitmasks and sync the overlay. */
-async function applySelectionUpdate(updater: (m: MapData, sels: Selection[]) => Selection[]) {
-	if (!currentMap) return;
-	const t = trace("selection", { summary: true });
-	selections = updater(currentMap, selections);
-	const sels = selections.map((s) => {
+/** Map the current selection stack to Rust `SelectionInput`s, resolving tag colors. */
+export function getSelectionInputs(): { props: SelectionProps; color: [number, number, number] }[] {
+	return selections.map((s) => {
 		let color = s.color;
 		if (s.props.type === "Tag" && currentMap) {
 			const tag = currentMap.meta.tags[s.props.tagId];
@@ -693,6 +690,14 @@ async function applySelectionUpdate(updater: (m: MapData, sels: Selection[]) => 
 		}
 		return { props: s.props, color };
 	});
+}
+
+/** Apply a pure selection transform, then IPC to Rust to resolve bitmasks and sync the overlay. */
+async function applySelectionUpdate(updater: (m: MapData, sels: Selection[]) => Selection[]) {
+	if (!currentMap) return;
+	const t = trace("selection", { summary: true });
+	selections = updater(currentMap, selections);
+	const sels = getSelectionInputs();
 	let result: SyncSelectionsResult;
 	try {
 		result = await cmd.storeSyncSelections(sels);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2862,7 +2862,7 @@ summary.button {
 	white-space: nowrap;
 }
 .manage-fields-modal {
-	max-width: 36rem;
+	max-width: 52rem;
 }
 .manage-fields-table {
 	width: 100%;
@@ -2888,6 +2888,10 @@ summary.button {
 .manage-fields-table .input {
 	width: 100%;
 	height: 28px;
+}
+.manage-fields-table .manage-fields-table__period {
+	width: 6em;
+	margin-top: 4px;
 }
 .manage-fields-table .nselect {
 	height: 28px;
@@ -4943,4 +4947,99 @@ body {
 		opacity: 1;
 		transform: translateY(0);
 	}
+}
+
+/* --- Disambiguate dialog (renders inside the light .modal) --- */
+.disambig-modal {
+	width: min(640px, 92vw);
+	color: #1a1a1a;
+}
+.disambig__muted {
+	color: #6b7280;
+	font-size: 0.85em;
+}
+.disambig__error {
+	color: #b91c1c;
+}
+.disambig__summary {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 12px;
+}
+.disambig__list {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	max-height: 60vh;
+	overflow-y: auto;
+	padding-bottom: 4px;
+}
+.disambig__row {
+	border: 1px solid #e5e7eb;
+	border-radius: 6px;
+	padding: 10px 12px;
+}
+.disambig__row--weak {
+	opacity: 0.6;
+}
+.disambig__head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.disambig__label {
+	font-weight: 600;
+}
+.disambig__badge {
+	font-size: 0.72em;
+	padding: 1px 6px;
+	border-radius: 4px;
+	background: #eef0f3;
+	color: #4b5563;
+}
+.disambig__badge--warn {
+	background: #fde68a;
+	color: #92400e;
+}
+.disambig__score {
+	margin-left: auto;
+	font-variant-numeric: tabular-nums;
+	font-weight: 700;
+}
+.disambig__bar {
+	height: 6px;
+	border-radius: 3px;
+	background: #eef0f3;
+	margin: 6px 0;
+	overflow: hidden;
+}
+.disambig__bar-fill {
+	height: 100%;
+	background: #2563eb;
+}
+.disambig__groups {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	margin-top: 6px;
+}
+.disambig__group {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+}
+.disambig__group-body {
+	font-size: 0.9em;
+}
+.disambig__coverage {
+	margin-top: 1px;
+}
+.disambig__swatch {
+	width: 10px;
+	height: 10px;
+	border-radius: 2px;
+	margin-top: 3px;
+	flex-shrink: 0;
+	box-shadow: 0 0 0 1px #0002;
 }

--- a/plugins/sunPosition/src/index.ts
+++ b/plugins/sunPosition/src/index.ts
@@ -4,7 +4,7 @@ import type { Location_Serialize, ExtraFieldDef } from "mma-plugin-types";
 const DEG = 180 / Math.PI;
 
 const FIELDS: Record<string, ExtraFieldDef> = {
-	sunAzimuth: { type: "number", label: "Sun azimuth" },
+	sunAzimuth: { type: "number", label: "Sun azimuth", comparison: { type: "circular", period: 360 } },
 	sunAltitude: { type: "number", label: "Sun altitude" },
 };
 

--- a/plugins/types/mma.d.ts
+++ b/plugins/types/mma.d.ts
@@ -67,6 +67,20 @@ export type CommitInfo = {
 	locationCount: number;
 	createdAt: string;
 };
+/**
+ *  How a field's values are compared when measuring how strongly it separates
+ *  groups (see `disambiguate`). The only un-inferrable property a field can
+ *  declare is circularity (heading/azimuth=360, hour-of-day=24, month=12);
+ *  everything else is inferred from `ExtraFieldType`.
+ */
+export type ComparisonType = {
+	type: "linear";
+} | {
+	type: "circular";
+	period: number;
+} | {
+	type: "categorical";
+};
 /**  Aggregate database statistics for the debug panel. */
 export type DbStats = {
 	maps: number;
@@ -137,6 +151,11 @@ export type ExtraFieldDef = {
 	labels?: {
 		[key in string]: string;
 	} | null;
+	/**
+	 *  Optional override for how this field is compared during disambiguation.
+	 *  `None` => inferred from `field_type` (see [`resolved_comparison`]).
+	 */
+	comparison?: ComparisonType | null;
 };
 /**
  *  Type discriminant for `Location.extra` field definitions.
@@ -632,6 +651,8 @@ export type WorkArea = "overview" | "location" | "duplicates" | "import" | "plug
 export interface EnrichFieldOption {
 	key: string;
 	label: string;
+	/** Excluded from the default field set (null enrichFields); user must opt in. */
+	defaultOff?: boolean;
 }
 declare function registerEnrichFields(fields: EnrichFieldOption[]): void;
 export interface EnrichmentProvider {
@@ -1168,6 +1189,17 @@ declare const mma: {
 		uninstallPlugin: (id: string) => Promise<null>;
 		checkBorderFile: (level: string) => Promise<boolean>;
 		downloadBorderFile: (level: string) => Promise<null>;
+		borderLookup: (lat: number, lng: number, level: string) => Promise<{
+			coordinates: (([
+				number,
+				number
+			])[])[];
+			extraPolygons?: ((([
+				number,
+				number
+			])[])[])[] | null;
+			properties?: any | null;
+		} | null>;
 		reverseGeocode: (lat: number, lng: number) => Promise<{
 			city: string;
 			admin: string;


### PR DESCRIPTION
Supervised analysis tool: given N selections, ranks each metadata field by **how strongly it separates the groups** (not by which value is most common).

## How it works
Each field gets a value-divergence score in [0,1], chosen by comparison type:
- **Linear numeric** → epsilon-squared from the Kruskal–Wallis H statistic (rank-based; robust to skew/scale)
- **Circular** (declared-circular fields) → one-way circular ANOVA decomposition (handles wrap-around; 350° and 10° are close)
- **Categorical / tags** → bias-corrected Cramér's V
- plus a separate **coverage-divergence** score for presence asymmetry

Missing values are excluded from value math (never treated as 0); locations in >1 group are dropped; a min-count guard flags low-confidence fields.

## Comparison type (circularity)
- `ComparisonType {Linear, Circular{period}, Categorical}` on `ExtraFieldDef`, resolved per field: plugin-declared > field-settings override > inferred from type.
- `heading` is the lone in-code circular column; everything extensible is declared.
- The **sunPosition plugin** declares `sunAzimuth` circular (period 360).
- **Manage Fields** gains a "Compare as" control with a free-form circular period.

## Excluded
lat/lng, countryCode, timezone

## UI
`DisambiguateDialog` + command-palette entry ("Disambiguate selections", enabled with ≥2 selections); date/season-aware value formatting.

## Tests
Rust unit tests in `disambiguate.test.rs` cover the statistical invariants (separation vs. shared modal value, circular wrap-around, coverage asymmetry, missing-data handling, overlap exclusion, low-confidence guard).