### PR TITLE
Bulk metadata field rename / merge / delete / set-value

### DIFF
--- a/app/src/components/dialogs/BulkOperationModal.tsx
+++ b/app/src/components/dialogs/BulkOperationModal.tsx
@@ -10,14 +10,15 @@ import {
 } from "@/store/useMapStore";
 import type { Location } from "@/types";
 import { isPinnedToPano } from "@/types";
-import { getFieldDef } from "@/lib/data/fieldDefRegistry";
+import { getFieldDef, getAllFieldDefs } from "@/lib/data/fieldDefRegistry";
+import { planFieldSet } from "@/lib/data/fieldOps.add";
 import { ValidationState } from "@/store/selections";
 import { validateLocations } from "@/lib/sv/validate";
 import { enrichAll, needsEnrichment, type EnrichResult } from "@/lib/sv/enrich.add";
 import { bulkPinToPano } from "@/lib/sv/pinPano.add";
 import { fmt } from "@/lib/util/format";
 
-export type BulkOperation = "validate" | "enrich" | "pinPano" | "clearFields";
+export type BulkOperation = "validate" | "enrich" | "pinPano" | "clearFields" | "setField";
 
 interface Props {
 	operation: BulkOperation;
@@ -29,7 +30,13 @@ const TITLES: Record<BulkOperation, string> = {
 	enrich: "Enrich metadata",
 	pinPano: "Pin to Pano ID",
 	clearFields: "Clear metadata fields",
+	setField: "Set metadata field",
 };
+
+interface SetFieldOpt {
+	key: string;
+	value: unknown;
+}
 
 type Scope = "all" | "selection";
 
@@ -78,7 +85,12 @@ function BulkSetup({
 	onStart,
 }: {
 	operation: BulkOperation;
-	onStart: (opts: { force: boolean; scope: Scope; clearKeys?: string[] }) => void;
+	onStart: (opts: {
+		force: boolean;
+		scope: Scope;
+		clearKeys?: string[];
+		setField?: SetFieldOpt;
+	}) => void;
 }) {
 	const [force, setForce] = useState(false);
 	const [locs, setLocs] = useState<Location[]>([]);
@@ -172,6 +184,19 @@ function BulkSetup({
 				allCount={total}
 				selectionCount={selectionCount}
 				onStart={(keys) => onStart({ force: false, scope, clearKeys: keys })}
+			/>
+		);
+	}
+
+	if (operation === "setField") {
+		return (
+			<SetFieldSetup
+				locs={locs}
+				scope={scope}
+				onScopeChange={setScope}
+				allCount={total}
+				selectionCount={selectionCount}
+				onStart={(setField) => onStart({ force: false, scope, setField })}
 			/>
 		);
 	}
@@ -278,6 +303,118 @@ function ClearFieldsSetup({
 	);
 }
 
+function SetFieldSetup({
+	locs,
+	scope,
+	onScopeChange,
+	allCount,
+	selectionCount,
+	onStart,
+}: {
+	locs: Location[];
+	scope: Scope;
+	onScopeChange: (s: Scope) => void;
+	allCount: number;
+	selectionCount: number;
+	onStart: (opt: SetFieldOpt) => void;
+}) {
+	const knownKeys = new Set<string>(Object.keys(getAllFieldDefs()));
+	for (const loc of locs) {
+		if (loc.extra) for (const k of Object.keys(loc.extra)) knownKeys.add(k);
+	}
+	const sortedKeys = [...knownKeys].sort();
+
+	const [key, setKey] = useState("");
+	const [creatingNew, setCreatingNew] = useState(false);
+	const [newKey, setNewKey] = useState("");
+	const [raw, setRaw] = useState("");
+
+	const effectiveKey = (creatingNew ? newKey : key).trim();
+	const def = effectiveKey ? getFieldDef(effectiveKey) : undefined;
+	const isNumber = def?.type === "number";
+	const isEnum = def?.type === "enum" && def.values;
+	const value: unknown = isNumber ? Number(raw) : raw;
+	const invalid = !effectiveKey || (isNumber && (raw === "" || Number.isNaN(Number(raw))));
+
+	return (
+		<div className="bulk-operation">
+			<ScopeToggle
+				scope={scope}
+				onScopeChange={onScopeChange}
+				allCount={allCount}
+				selectionCount={selectionCount}
+			/>
+			<label className="bulk-operation__option">
+				Field
+				<select
+					className="nselect"
+					value={creatingNew ? "__new__" : key}
+					onChange={(e) => {
+						if (e.target.value === "__new__") {
+							setCreatingNew(true);
+						} else {
+							setCreatingNew(false);
+							setKey(e.target.value);
+						}
+					}}
+				>
+					<option value="" disabled>
+						Select a field...
+					</option>
+					{sortedKeys.map((k) => (
+						<option key={k} value={k}>
+							{getFieldDef(k)?.label ?? k}
+						</option>
+					))}
+					<option value="__new__">New field...</option>
+				</select>
+			</label>
+			{creatingNew && (
+				<label className="bulk-operation__option">
+					New field name
+					<input
+						className="input"
+						value={newKey}
+						onChange={(e) => setNewKey(e.target.value)}
+						placeholder="field name"
+						autoFocus
+					/>
+				</label>
+			)}
+			<label className="bulk-operation__option">
+				Value
+				{isEnum ? (
+					<select className="nselect" value={raw} onChange={(e) => setRaw(e.target.value)}>
+						<option value="" />
+						{def!.values!.map((v) => (
+							<option key={v} value={v}>
+								{def!.labels?.[v] ?? v}
+							</option>
+						))}
+					</select>
+				) : (
+					<input
+						className="input"
+						type={isNumber ? "number" : "text"}
+						value={raw}
+						onChange={(e) => setRaw(e.target.value)}
+					/>
+				)}
+			</label>
+			<div className="bulk-operation__actions">
+				<button
+					className="button button--primary"
+					type="button"
+					disabled={invalid}
+					onClick={() => onStart({ key: effectiveKey, value })}
+				>
+					Set field
+				</button>
+			</div>
+		</div>
+	);
+}
+
 function EnrichSummary({
 	result,
 	onSelect,
@@ -333,6 +470,7 @@ function BulkProgress({
 	scope,
 	selectedIds,
 	clearKeys,
+	setField,
 	onClose,
 }: {
 	operation: BulkOperation;
@@ -340,6 +478,7 @@ function BulkProgress({
 	scope: Scope;
 	selectedIds: Set<number>;
 	clearKeys?: string[];
+	setField?: SetFieldOpt;
 	onClose: () => void;
 }) {
 	const [progress, setProgress] = useState(0);
@@ -427,6 +566,17 @@ function BulkProgress({
 				}
 				setDone(updates.length);
 				setClearCount(updates.length);
+			} else if (operation === "setField" && setField) {
+				const updates = planFieldSet(locations, setField.key, setField.value).map((u) => ({
+					id: u.id,
+					patch: { extra: u.extra },
+				}));
+				setTotal(updates.length);
+				if (updates.length > 0) {
+					await batchUpdateLocations(updates);
+				}
+				setDone(updates.length);
+				setClearCount(updates.length);
 			}
 			setProgress(1);
 			setStatus("done");
@@ -438,7 +588,7 @@ function BulkProgress({
 				setStatus("error");
 			}
 		}
-	}, [operation, force, clearKeys]);
+	}, [operation, force, clearKeys, setField]);
 
 	useEffect(() => {
 		run();
@@ -462,6 +612,8 @@ function BulkProgress({
 					/>
 				) : status === "done" && operation === "clearFields" ? (
 					`Cleared fields from ${fmt.format(clearCount)} locations.`
+				) : status === "done" && operation === "setField" ? (
+					`Set field on ${fmt.format(clearCount)} locations.`
 				) : (
 					status === "done" && `Done -- ${fmt.format(total)} locations processed.`
 				)}
@@ -493,6 +645,7 @@ export function BulkOperationModal({ operation, onClose }: Props) {
 	const [force, setForce] = useState(false);
 	const [scope, setScope] = useState<Scope>("all");
 	const [clearKeys, setClearKeys] = useState<string[]>([]);
+	const [setField, setSetField] = useState<SetFieldOpt | undefined>(undefined);
 	const selectedIds = useSelectedLocationIds();
 
 	return (
@@ -510,6 +663,7 @@ export function BulkOperationModal({ operation, onClose }: Props) {
 							setForce(opts.force);
 							setScope(opts.scope);
 							if (opts.clearKeys) setClearKeys(opts.clearKeys);
+							if (opts.setField) setSetField(opts.setField);
 							setStarted(true);
 						}}
 					/>
@@ -520,6 +674,7 @@ export function BulkOperationModal({ operation, onClose }: Props) {
 						scope={scope}
 						selectedIds={selectedIds}
 						clearKeys={clearKeys}
+						setField={setField}
 						onClose={onClose}
 					/>
 				)}

--- a/app/src/components/dialogs/ManageFieldsModal.add.tsx
+++ b/app/src/components/dialogs/ManageFieldsModal.add.tsx
@@ -1,8 +1,15 @@
 import { useState } from "react";
 import { Dialog, DialogContent } from "@/components/primitives/Dialog";
-import { setMapExtraFields, getKnownFieldKeys } from "@/store/useMapStore";
+import {
+	setMapExtraFields,
+	getKnownFieldKeys,
+	renameField,
+	deleteField,
+} from "@/store/useMapStore";
 import type { ExtraFieldDef } from "@/types";
+import type { MergeWinner } from "@/lib/data/fieldOps.add";
 import { getFieldDef, getAllFieldDefs } from "@/lib/data/fieldDefRegistry";
+
 const FIELD_TYPES: ExtraFieldDef["type"][] = ["string", "number", "date", "month", "enum"];
 const TYPE_LABELS: Record<ExtraFieldDef["type"], string> = {
 	string: "Text",
@@ -19,14 +26,16 @@ interface FieldRow {
 	hasData: boolean;
 }
 
-export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
+type Action =
+	| { kind: "rename"; key: string; target: string; winner: MergeWinner }
+	| { kind: "delete"; key: string };
+
+function buildRows(): FieldRow[] {
 	const knownKeys = getKnownFieldKeys();
 	const allDefs = getAllFieldDefs();
-
-	const allKeys = new Set<string>(knownKeys);
-	for (const k of Object.keys(allDefs)) allKeys.add(k);
-
-	const initialRows: FieldRow[] = [...allKeys].sort().map((key) => {
+	const keys = new Set<string>(knownKeys);
+	for (const k of Object.keys(allDefs)) keys.add(k);
+	return [...keys].sort().map((key) => {
 		const def = getFieldDef(key);
 		return {
 			key,
@@ -35,8 +44,14 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 			hasData: knownKeys.has(key),
 		};
 	});
+}
 
-	const [rows, setRows] = useState(initialRows);
+export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
+	const [rows, setRows] = useState(buildRows);
+	const [action, setAction] = useState<Action | null>(null);
+	const [busy, setBusy] = useState(false);
+
+	const existingKeys = new Set(rows.map((r) => r.key));
 
 	const updateRow = (key: string, patch: Partial<FieldRow>) => {
 		setRows((prev) => prev.map((r) => (r.key === key ? { ...r, ...patch } : r)));
@@ -55,6 +70,39 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 		onClose();
 	};
 
+	const applyRename = async () => {
+		if (action?.kind !== "rename") return;
+		const target = action.target.trim();
+		if (!target || target === action.key) {
+			setAction(null);
+			return;
+		}
+		setBusy(true);
+		try {
+			await renameField(action.key, target, action.winner);
+		} finally {
+			setBusy(false);
+		}
+		setRows(buildRows());
+		setAction(null);
+	};
+
+	const applyDelete = async () => {
+		if (action?.kind !== "delete") return;
+		setBusy(true);
+		try {
+			await deleteField(action.key);
+		} finally {
+			setBusy(false);
+		}
+		setRows(buildRows());
+		setAction(null);
+	};
+
+	const renameTarget = action?.kind === "rename" ? action.target.trim() : "";
+	const isMerge =
+		action?.kind === "rename" && existingKeys.has(renameTarget) && renameTarget !== action.key;
+
 	return (
 		<Dialog
 			open
@@ -72,6 +120,7 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 								<th>Field</th>
 								<th>Label</th>
 								<th>Type</th>
+								<th />
 							</tr>
 						</thead>
 						<tbody>
@@ -105,16 +154,131 @@ export function ManageFieldsModal({ onClose }: { onClose: () => void }) {
 											))}
 										</select>
 									</td>
+									<td className="manage-fields-table__actions">
+										<button
+											className="button button--small"
+											type="button"
+											disabled={busy}
+											onClick={() =>
+												setAction({ kind: "rename", key: row.key, target: row.key, winner: "from" })
+											}
+										>
+											Rename / merge
+										</button>
+										<button
+											className="button button--small button--danger"
+											type="button"
+											disabled={busy}
+											onClick={() => setAction({ kind: "delete", key: row.key })}
+										>
+											Delete
+										</button>
+									</td>
 								</tr>
 							))}
 						</tbody>
 					</table>
 				)}
+
+				{action?.kind === "rename" && (
+					<div className="manage-fields-action">
+						<label>
+							Rename <code>{action.key}</code> to:
+							<input
+								className="input"
+								list="manage-fields-keys"
+								autoFocus
+								value={action.target}
+								onChange={(e) => setAction({ ...action, target: e.target.value })}
+								placeholder="new or existing field name"
+							/>
+						</label>
+						<datalist id="manage-fields-keys">
+							{rows.map((r) => (
+								<option key={r.key} value={r.key} />
+							))}
+						</datalist>
+						{isMerge && (
+							<fieldset className="manage-fields-action__winner">
+								<legend>
+									<code>{renameTarget}</code> already exists. On conflict, keep:
+								</legend>
+								<label>
+									<input
+										type="radio"
+										checked={action.winner === "from"}
+										onChange={() => setAction({ ...action, winner: "from" })}
+									/>{" "}
+									{action.key}&apos;s values
+								</label>
+								<label>
+									<input
+										type="radio"
+										checked={action.winner === "to"}
+										onChange={() => setAction({ ...action, winner: "to" })}
+									/>{" "}
+									{renameTarget}&apos;s values
+								</label>
+							</fieldset>
+						)}
+						<div className="manage-fields-action__buttons">
+							<button
+								className="button button--primary"
+								type="button"
+								disabled={busy || !renameTarget || renameTarget === action.key}
+								onClick={applyRename}
+							>
+								{isMerge ? "Merge" : "Rename"}
+							</button>
+							<button
+								className="button"
+								type="button"
+								disabled={busy}
+								onClick={() => setAction(null)}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				)}
+
+				{action?.kind === "delete" && (
+					<div className="manage-fields-action">
+						<p>
+							Delete <code>{action.key}</code> and clear its values from every location? This
+							cannot be undone after committing.
+						</p>
+						<div className="manage-fields-action__buttons">
+							<button
+								className="button button--danger"
+								type="button"
+								disabled={busy}
+								onClick={applyDelete}
+							>
+								Delete field
+							</button>
+							<button
+								className="button"
+								type="button"
+								disabled={busy}
+								onClick={() => setAction(null)}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				)}
+
 				<div className="manage-fields-modal__actions">
-					<button className="button button--primary" type="button" onClick={handleSave}>
+					<button
+						className="button button--primary"
+						type="button"
+						disabled={busy}
+						onClick={handleSave}
+					>
 						Save
 					</button>
-					<button className="button" type="button" onClick={onClose}>
+					<button className="button" type="button" disabled={busy} onClick={onClose}>
 						Cancel
 					</button>
 				</div>

--- a/app/src/lib/data/fieldOps.add.ts
+++ b/app/src/lib/data/fieldOps.add.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure planning logic for bulk metadata-field operations (rename / merge / delete / set).
+ * These compute the `extra` replacement blobs and selection-reference rewrites; the store
+ * orchestrates IPC, definitions, and persistence. Kept side-effect-free for testability.
+ */
+
+import type { Location, MapData } from "@/types";
+import type { Selection, SelectionProps } from "@/store/selections";
+import { buildSelection } from "@/store/selections";
+
+/** When a move target already holds a value, which field's value survives. */
+export type MergeWinner = "from" | "to";
+
+/** A planned change to one location's `extra` (the full replacement blob). */
+export interface ExtraUpdate {
+	id: number;
+	extra: Record<string, unknown>;
+}
+
+/**
+ * Rename/merge field `from` into `to`. Rename and merge are the same operation —
+ * "rename" is just the case where no location already has `to`. When a location has
+ * both keys, `winner` decides which value survives under the `to` key.
+ * Returns updates only for locations that actually change.
+ */
+export function planFieldMove(
+	locations: Location[],
+	from: string,
+	to: string,
+	winner: MergeWinner,
+): ExtraUpdate[] {
+	if (from === to || !to) return [];
+	const updates: ExtraUpdate[] = [];
+	for (const loc of locations) {
+		const extra = loc.extra;
+		if (!extra || !(from in extra)) continue;
+		const next = { ...extra };
+		const fromVal = next[from];
+		const hasTo = to in next;
+		delete next[from];
+		if (!hasTo || winner === "from") next[to] = fromVal;
+		// winner === "to" with existing target: keep `next[to]` untouched
+		updates.push({ id: loc.id, extra: next });
+	}
+	return updates;
+}
+
+/** Remove field `key` from every location that has it. */
+export function planFieldDelete(locations: Location[], key: string): ExtraUpdate[] {
+	const updates: ExtraUpdate[] = [];
+	for (const loc of locations) {
+		if (!loc.extra || !(key in loc.extra)) continue;
+		const next = { ...loc.extra };
+		delete next[key];
+		updates.push({ id: loc.id, extra: next });
+	}
+	return updates;
+}
+
+/** Set field `key` to `value` on the given locations, skipping those already equal. */
+export function planFieldSet(locations: Location[], key: string, value: unknown): ExtraUpdate[] {
+	const updates: ExtraUpdate[] = [];
+	for (const loc of locations) {
+		if (loc.extra && loc.extra[key] === value) continue;
+		updates.push({ id: loc.id, extra: { ...(loc.extra ?? {}), [key]: value } });
+	}
+	return updates;
+}
+
+/**
+ * Rewrite Filter `field` references in a selection tree: `from` → `to`, or drop the
+ * Filter when `to` is null (field deleted). Composites collapse if emptied, or unwrap
+ * to their sole survivor (matching the rest of the selection engine's semantics).
+ */
+function rewriteSelection(
+	map: MapData,
+	sel: Selection,
+	from: string,
+	to: string | null,
+): Selection | null {
+	const p = sel.props;
+	if (p.type === "Filter") {
+		if (p.field !== from) return sel;
+		return to === null ? null : buildSelection(map, { ...p, field: to });
+	}
+	if ("selections" in p) {
+		const children = p.selections
+			.map((c) => rewriteSelection(map, c, from, to))
+			.filter((c): c is Selection => c !== null);
+		if (children.length === 0) return null;
+		if (children.length === 1 && p.type !== "Invert") return children[0];
+		return buildSelection(map, { ...p, selections: children } as SelectionProps);
+	}
+	return sel;
+}
+
+export function rewriteSelectionFields(
+	map: MapData,
+	selections: Selection[],
+	from: string,
+	to: string | null,
+): Selection[] {
+	return selections
+		.map((s) => rewriteSelection(map, s, from, to))
+		.filter((s): s is Selection => s !== null);
+}

--- a/app/src/store/commandDefs.add.ts
+++ b/app/src/store/commandDefs.add.ts
@@ -17,6 +17,7 @@ import {
 	mdiEye,
 	mdiTagRemove,
 	mdiDatabaseRemoveOutline,
+	mdiDatabaseEditOutline,
 	mdiFindReplace,
 } from "@mdi/js";
 import { registerCommand } from "./commands.add";
@@ -172,6 +173,14 @@ registerCommand({
 	icon: mdiDatabaseArrowUp,
 	group: "Bulk Operations",
 	execute: () => document.dispatchEvent(new CustomEvent("open-bulk-op", { detail: "enrich" })),
+});
+
+registerCommand({
+	id: "bulk-set-field",
+	label: "Set metadata field value",
+	icon: mdiDatabaseEditOutline,
+	group: "Bulk Operations",
+	execute: () => document.dispatchEvent(new CustomEvent("open-bulk-op", { detail: "setField" })),
 });
 
 registerCommand({

--- a/app/src/store/savedSelections.add.ts
+++ b/app/src/store/savedSelections.add.ts
@@ -128,6 +128,43 @@ export function describeRule(props: SavedSelectionProps): string {
 	}
 }
 
+/**
+ * Rewrite Filter `field` references in persisted saved selections: `from` → `to`, or
+ * drop the Filter (and any selection/composite that empties) when `to` is null.
+ */
+export function rewriteSavedSelectionFields(
+	saved: SavedSelection[],
+	from: string,
+	to: string | null,
+): SavedSelection[] {
+	const rewriteProps = (p: SavedSelectionProps): SavedSelectionProps | null => {
+		if (p.type === "Filter") {
+			if (p.field !== from) return p;
+			return to === null ? null : { ...p, field: to };
+		}
+		if (p.type === "Intersection" || p.type === "Union" || p.type === "Invert") {
+			const children = p.selections
+				.map(rewriteProps)
+				.filter((c): c is SavedSelectionProps => c !== null);
+			if (children.length === 0) return null;
+			if (children.length === 1 && p.type !== "Invert") return children[0];
+			return { ...p, selections: children };
+		}
+		return p;
+	};
+	return saved
+		.map((s) => ({
+			...s,
+			items: s.items
+				.map((it) => {
+					const props = rewriteProps(it.props);
+					return props ? { ...it, props } : null;
+				})
+				.filter((it): it is SavedSelectionItem => it !== null),
+		}))
+		.filter((s) => s.items.length > 0);
+}
+
 // CRUD
 
 export function getSavedSelections(): SavedSelection[] {

--- a/app/src/store/useMapStore.ts
+++ b/app/src/store/useMapStore.ts
@@ -14,6 +14,14 @@ import { trace } from "@/lib/util/debug";
 import { mmaBufUrl } from "@/lib/util/util";
 import { getTriggeredProviders } from "@/lib/data/fieldDefs.add";
 import { setUserFieldDefs, resetForMapChange } from "@/lib/data/fieldDefRegistry";
+import {
+	planFieldMove,
+	planFieldDelete,
+	rewriteSelectionFields,
+	type MergeWinner,
+} from "@/lib/data/fieldOps.add";
+import { getSavedSelections, rewriteSavedSelectionFields } from "./savedSelections.add";
+import { setSetting } from "./settings.add";
 import type { RenderDelta } from "@/lib/render/CellManager";
 
 /** Minimal pub/sub bus. `.on()` returns an unsubscribe function. */
@@ -650,6 +658,46 @@ export async function patchLocationExtra(
 		const merged = Object.assign({}, ...results.filter(Boolean));
 		if (Object.keys(merged).length > 0) await patchLocationExtra(patched, merged);
 	}
+}
+
+// --- Bulk metadata-field operations (rare; one undo entry each) ---
+
+/** Rename or merge extra-field `from` into `to` across all locations, then migrate
+ *  its definition and every selection that references it. Merge ≡ rename; `winner`
+ *  decides the survivor only where a location already holds `to`. */
+export async function renameField(from: string, to: string, winner: MergeWinner = "from") {
+	if (!currentMap || from === to || !to) return;
+	const updates = planFieldMove(await fetchAllLocations(), from, to, winner);
+	if (updates.length) {
+		await batchUpdateLocations(updates.map((u) => ({ id: u.id, patch: { extra: u.extra } })));
+		knownFieldKeys.add(to);
+	}
+	knownFieldKeys.delete(from);
+	await migrateFieldReferences(from, to);
+}
+
+/** Delete extra-field `key` from every location, its definition, and references. */
+export async function deleteField(key: string) {
+	if (!currentMap) return;
+	const updates = planFieldDelete(await fetchAllLocations(), key);
+	if (updates.length) {
+		await batchUpdateLocations(updates.map((u) => ({ id: u.id, patch: { extra: u.extra } })));
+	}
+	knownFieldKeys.delete(key);
+	await migrateFieldReferences(key, null);
+}
+
+/** Migrate field definition + active/saved selection references after a data move. */
+async function migrateFieldReferences(from: string, to: string | null) {
+	if (!currentMap) return;
+	const defs = { ...(currentMap.meta.extra?.fields ?? {}) };
+	if (defs[from]) {
+		if (to && !defs[to]) defs[to] = defs[from];
+		delete defs[from];
+		await setMapExtraFields(defs);
+	}
+	setSetting("savedSelections", rewriteSavedSelectionFields(getSavedSelections(), from, to));
+	await applySelectionUpdate((m, sels) => rewriteSelectionFields(m, sels, from, to));
 }
 
 // --- Selections ---

--- a/app/src/store/useMapStore.ts
+++ b/app/src/store/useMapStore.ts
@@ -629,6 +629,16 @@ export function batchUpdateLocations(updates: { id: number; patch: Partial<Locat
 	);
 }
 
+// Like batchUpdateLocations but records no undo entry. Used by bulk field ops whose
+// definition/selection migration isn't part of the undo system — an undoable data
+// change there would half-revert and leave the map inconsistent.
+function batchUpdateLocationsNoUndo(updates: { id: number; patch: Partial<Location> }[]) {
+	if (!currentMap || updates.length === 0) return Promise.resolve();
+	return mutate(cmd.storeUpdateLocations(buildUpdates(updates), false)).catch((e) =>
+		log.error("[batchUpdateNoUndo] store_update_locations failed:", e),
+	);
+}
+
 export async function patchLocationExtra(
 	loc: Location,
 	extraPatch: Record<string, unknown>,
@@ -660,7 +670,8 @@ export async function patchLocationExtra(
 	}
 }
 
-// --- Bulk metadata-field operations (rare; one undo entry each) ---
+// --- Bulk metadata-field operations (rare; intentionally NOT undoable, since the
+//     definition/selection migration below isn't part of the undo system) ---
 
 /** Rename or merge extra-field `from` into `to` across all locations, then migrate
  *  its definition and every selection that references it. Merge ≡ rename; `winner`
@@ -669,7 +680,7 @@ export async function renameField(from: string, to: string, winner: MergeWinner 
 	if (!currentMap || from === to || !to) return;
 	const updates = planFieldMove(await fetchAllLocations(), from, to, winner);
 	if (updates.length) {
-		await batchUpdateLocations(updates.map((u) => ({ id: u.id, patch: { extra: u.extra } })));
+		await batchUpdateLocationsNoUndo(updates.map((u) => ({ id: u.id, patch: { extra: u.extra } })));
 		knownFieldKeys.add(to);
 	}
 	knownFieldKeys.delete(from);
@@ -681,7 +692,7 @@ export async function deleteField(key: string) {
 	if (!currentMap) return;
 	const updates = planFieldDelete(await fetchAllLocations(), key);
 	if (updates.length) {
-		await batchUpdateLocations(updates.map((u) => ({ id: u.id, patch: { extra: u.extra } })));
+		await batchUpdateLocationsNoUndo(updates.map((u) => ({ id: u.id, patch: { extra: u.extra } })));
 	}
 	knownFieldKeys.delete(key);
 	await migrateFieldReferences(key, null);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2886,7 +2886,8 @@ summary.button {
 	white-space: nowrap;
 }
 .manage-fields-modal {
-	max-width: 36rem;
+	max-width: 48rem;
+	width: 90vw;
 }
 .manage-fields-table {
 	width: 100%;
@@ -2921,6 +2922,55 @@ summary.button {
 	justify-content: flex-end;
 	gap: 0.5rem;
 	margin-top: 0.5rem;
+}
+.manage-fields-table__actions {
+	display: flex;
+	gap: 0.375rem;
+	justify-content: flex-end;
+	white-space: nowrap;
+}
+.button--small {
+	padding: 0.1875rem 0.5rem;
+	font-size: 0.75rem;
+	height: auto;
+}
+.manage-fields-action {
+	margin-top: 0.75rem;
+	padding: 0.75rem;
+	border: 1px solid #0002;
+	border-radius: 6px;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	font-size: 0.8125rem;
+}
+.manage-fields-action > label {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+.manage-fields-action code {
+	font-family: monospace;
+}
+.manage-fields-action__winner {
+	border: 1px solid #0002;
+	border-radius: 6px;
+	padding: 0.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+.manage-fields-action__winner legend {
+	padding: 0 0.25rem;
+}
+.manage-fields-action__winner label {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+}
+.manage-fields-action__buttons {
+	display: flex;
+	gap: 0.5rem;
 }
 .extra-filter-builder {
 	display: flex;

--- a/app/test/unit/fieldOps.test.ts
+++ b/app/test/unit/fieldOps.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+	planFieldMove,
+	planFieldDelete,
+	planFieldSet,
+	rewriteSelectionFields,
+} from "@/lib/data/fieldOps.add";
+import { buildSelection } from "@/store/selections";
+import type { Location, MapData } from "@/types";
+
+function makeLoc(id: number, extra?: Record<string, unknown>): Location {
+	return {
+		id,
+		lat: 0,
+		lng: 0,
+		heading: 0,
+		pitch: 0,
+		zoom: 0,
+		panoId: null,
+		flags: 0,
+		tags: [],
+		extra,
+		createdAt: "",
+		modifiedAt: null,
+	} as Location;
+}
+
+const map = { meta: { tags: {} } } as unknown as MapData;
+
+describe("planFieldMove", () => {
+	it("renames a key (target absent)", () => {
+		const out = planFieldMove([makeLoc(1, { a: 5 })], "a", "b", "from");
+		expect(out).toEqual([{ id: 1, extra: { b: 5 } }]);
+	});
+
+	it("merge: winner 'from' takes the moved value", () => {
+		const out = planFieldMove([makeLoc(1, { a: 5, b: 9 })], "a", "b", "from");
+		expect(out).toEqual([{ id: 1, extra: { b: 5 } }]);
+	});
+
+	it("merge: winner 'to' keeps the existing target value", () => {
+		const out = planFieldMove([makeLoc(1, { a: 5, b: 9 })], "a", "b", "to");
+		expect(out).toEqual([{ id: 1, extra: { b: 9 } }]);
+	});
+
+	it("skips locations without the source key", () => {
+		expect(planFieldMove([makeLoc(1, { x: 1 })], "a", "b", "from")).toEqual([]);
+	});
+
+	it("preserves unrelated keys", () => {
+		const out = planFieldMove([makeLoc(1, { a: 5, keep: 1 })], "a", "b", "from");
+		expect(out[0].extra).toEqual({ b: 5, keep: 1 });
+	});
+
+	it("is a no-op when from === to or to is empty", () => {
+		expect(planFieldMove([makeLoc(1, { a: 5 })], "a", "a", "from")).toEqual([]);
+		expect(planFieldMove([makeLoc(1, { a: 5 })], "a", "", "from")).toEqual([]);
+	});
+});
+
+describe("planFieldDelete", () => {
+	it("removes the key from locations that have it", () => {
+		const out = planFieldDelete([makeLoc(1, { a: 5, b: 9 }), makeLoc(2, { b: 1 })], "a");
+		expect(out).toEqual([{ id: 1, extra: { b: 9 } }]);
+	});
+});
+
+describe("planFieldSet", () => {
+	it("sets the value, creating extra when absent", () => {
+		const out = planFieldSet([makeLoc(1), makeLoc(2, { k: "old" })], "k", "new");
+		expect(out).toEqual([
+			{ id: 1, extra: { k: "new" } },
+			{ id: 2, extra: { k: "new" } },
+		]);
+	});
+
+	it("skips locations already equal", () => {
+		expect(planFieldSet([makeLoc(1, { k: "v" })], "k", "v")).toEqual([]);
+	});
+});
+
+describe("rewriteSelectionFields", () => {
+	const filter = (field: string) =>
+		buildSelection(map, { type: "Filter", field, op: "eq", value: 1, value2: null });
+
+	it("rewrites a Filter field and regenerates its key", () => {
+		const out = rewriteSelectionFields(map, [filter("a")], "a", "b");
+		expect(out).toHaveLength(1);
+		expect((out[0].props as { field: string }).field).toBe("b");
+		expect(out[0].key).toBe("filter:b:eq:1");
+	});
+
+	it("leaves unrelated filters untouched", () => {
+		const f = filter("c");
+		const out = rewriteSelectionFields(map, [f], "a", "b");
+		expect(out[0].key).toBe(f.key);
+	});
+
+	it("drops a Filter when the field is deleted (to = null)", () => {
+		expect(rewriteSelectionFields(map, [filter("a")], "a", null)).toEqual([]);
+	});
+
+	it("rewrites filters nested in a composite", () => {
+		const union = buildSelection(map, { type: "Union", selections: [filter("a"), filter("c")] });
+		const out = rewriteSelectionFields(map, [union], "a", "b");
+		const children = (out[0].props as { selections: { props: { field: string } }[] }).selections;
+		expect(children.map((c) => c.props.field)).toEqual(["b", "c"]);
+	});
+
+	it("collapses a group to its sole survivor when a child is deleted", () => {
+		const tag = buildSelection(map, { type: "Tag", tagId: 1 });
+		const union = buildSelection(map, { type: "Union", selections: [filter("a"), tag] });
+		const out = rewriteSelectionFields(map, [union], "a", null);
+		expect(out).toHaveLength(1);
+		expect(out[0].props.type).toBe("Tag");
+	});
+});

--- a/app/test/unit/savedSelections.test.ts
+++ b/app/test/unit/savedSelections.test.ts
@@ -4,6 +4,8 @@ import {
 	selectionToSaved,
 	savedToSelectionProps,
 	describeRule,
+	rewriteSavedSelectionFields,
+	type SavedSelection,
 	type SavedSelectionProps,
 } from "@/store/savedSelections.add";
 import type { MapData, Tag } from "@/types";
@@ -39,6 +41,55 @@ function makeMap(tags: Record<number, Tag> = {}): MapData {
 function makeSel(props: Selection["props"]): Selection {
 	return { key: "test", color: [100, 100, 100], props, count: 0 };
 }
+
+// ============================================================================
+// rewriteSavedSelectionFields
+// ============================================================================
+
+describe("rewriteSavedSelectionFields", () => {
+	const wrap = (props: SavedSelectionProps): SavedSelection => ({
+		id: "s1",
+		name: "n",
+		items: [{ props, color: [0, 0, 0] }],
+		createdAt: 0,
+	});
+
+	it("renames a Filter field", () => {
+		const out = rewriteSavedSelectionFields(
+			[wrap({ type: "Filter", field: "a", op: "eq", value: 1 })],
+			"a",
+			"b",
+		);
+		expect((out[0].items[0].props as any).field).toBe("b");
+	});
+
+	it("drops a saved selection whose only Filter is deleted", () => {
+		const out = rewriteSavedSelectionFields(
+			[wrap({ type: "Filter", field: "a", op: "eq", value: 1 })],
+			"a",
+			null,
+		);
+		expect(out).toEqual([]);
+	});
+
+	it("rewrites filters nested in a composite and collapses singletons", () => {
+		const out = rewriteSavedSelectionFields(
+			[
+				wrap({
+					type: "Union",
+					selections: [
+						{ type: "Filter", field: "a", op: "eq", value: 1 },
+						{ type: "Untagged" },
+					],
+				}),
+			],
+			"a",
+			null,
+		);
+		// Union loses its Filter child, collapsing to the lone Untagged
+		expect(out[0].items[0].props.type).toBe("Untagged");
+	});
+});
 
 // ============================================================================
 // selectionToSaved


### PR DESCRIPTION
Bulk operations for managing metadata (`extra`) fields across a map.

## What
- **Rename / merge** a field (`from` → `to`) across all locations. Merge ≡ rename — "rename" is just the case where nothing already holds `to`; a `winner` decides the survivor on collisions.
- **Delete** a field from every location.
- **Set value** in bulk via the BulkOperation modal.

Each op also migrates the field **definition**, **active selections**, and **saved selections** that reference the field (rewriting Filter references; composites collapse/unwrap when emptied).

## Design notes
- Pure planning logic lives in `lib/data/fieldOps.add.ts` (side-effect-free, fully unit-tested); the store orchestrates IPC/definitions/persistence.
- **Intentionally not undoable** — the definition/selection migration isn't part of the undo system, so the data write is routed through a no-undo path to avoid a half-reverted, inconsistent state.

## Tests
- `fieldOps.test.ts` (14) and `savedSelections.test.ts` (rewrite cases) — rename/merge/delete/set + selection-rewrite edge cases (key regen, drop-on-delete, nested composite, collapse-to-sole-survivor).