### PR TITLE
Basemap UI & FullScreen Minimap & legacy tile stacking improvements

### DIFF
--- a/app/src/components/editor/location/FullscreenMiniMap.tsx
+++ b/app/src/components/editor/location/FullscreenMiniMap.tsx
@@ -145,8 +145,8 @@ export function FullscreenMiniMap() {
 		<div
 			className={`fullscreen-minimap${expanded ? " is-expanded" : ""}`}
 			style={sizeVars}
-			onMouseEnter={open}
-			onMouseLeave={scheduleClose}
+			onPointerEnter={open}
+			onPointerLeave={scheduleClose}
 		>
 			<div ref={containerRef} className="fullscreen-minimap__map" />
 			<div className="fullscreen-minimap__size">

--- a/app/src/components/editor/map/MapSettingsPanel.tsx
+++ b/app/src/components/editor/map/MapSettingsPanel.tsx
@@ -279,10 +279,12 @@ function BasemapSelector({
 	previewUrls,
 	selected,
 	onSelect,
+	onMouseEnter,
 }: {
 	previewUrls: Record<MapTypeKey, string>;
 	selected: MapTypeKey;
 	onSelect: (type: MapTypeKey) => void;
+	onMouseEnter?: () => void;
 }) {
 	return (
 		<div className="map-type-control__basemap">
@@ -293,6 +295,7 @@ function BasemapSelector({
 					className="map-type-control__button"
 					data-state={selected === t ? "on" : "off"}
 					onClick={() => onSelect(t)}
+					onMouseEnter={onMouseEnter}
 				>
 					<div className="map-type-control__background">
 						<img src={previewUrls[t]} alt="" draggable={false} />
@@ -374,10 +377,6 @@ export function MapTypeDropdown({ layerConfig }: { layerConfig: LayerConfig }) {
 	const mapPreviewUrl = useMemo(() => buildTileUrl(createRoadmapTileConfig(), 0, 0, 0), []);
 
 	useEffect(() => {
-		setIsOpen(false);
-	}, [compact]);
-
-	useEffect(() => {
 		if (!isOpen) return;
 		const handler = (e: MouseEvent) => {
 			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -457,6 +456,9 @@ export function MapTypeDropdown({ layerConfig }: { layerConfig: LayerConfig }) {
 								layerConfig.setBasemap(t);
 								setIsOpen(false);
 							}
+						}}
+						onMouseEnter={() => {
+							setIsOpen(true);
 						}}
 					/>
 					{settingsPopup}

--- a/app/src/components/editor/map/MapSettingsPanel.tsx
+++ b/app/src/components/editor/map/MapSettingsPanel.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo, type RefObject } from "react";
 import { ManageFieldsModal } from "@/components/dialogs/ManageFieldsModal";
 import { getEnrichFieldOptions, getDefaultEnrichKeys } from "@/lib/data/fieldDefs";
 import { Dialog, DialogContent } from "@/components/primitives/Dialog";
-import type { MapStyle } from "@/lib/geo/tiles";
+import { buildTileUrl, createRoadmapTileConfig, type MapStyle } from "@/lib/geo/tiles";
 import { BUILTIN_STYLE_KEYS, BUILTIN_STYLE_LABELS } from "@/lib/geo/mapStyles";
 import { EnrichInfoButton } from "@/components/editor/map/EnrichInfoButton";
 import { Icon } from "@/components/primitives/Icon";
@@ -235,28 +235,25 @@ function SettingsPopup({ layerConfig: e }: { layerConfig: LayerConfig }) {
 				<legend className="layer-config__header">
 					Map&nbsp;style <span className="layer-config__divider" />
 				</legend>
-				{BUILTIN_STYLE_KEYS.map((key) => (
-					<label key={key} className="layer-config__item">
-						<input
-							type="radio"
-							name="mapstyle"
-							checked={e.mapStyleName === key}
-							onChange={() => e.setMapStyleName(key)}
-						/>
-						{BUILTIN_STYLE_LABELS[key]}
-					</label>
-				))}
-				{e.customStyles.map((s) => (
-					<label key={s.name} className="layer-config__item">
-						<input
-							type="radio"
-							name="mapstyle"
-							checked={e.mapStyleName === s.name}
-							onChange={() => e.setMapStyleName(s.name)}
-						/>
-						{s.name}
-					</label>
-				))}
+				<label className="layer-config__item settings-popup__select">
+					Style:{" "}
+					<select
+						className="nselect nselect--limited"
+						value={e.mapStyleName}
+						onChange={(ev) => e.setMapStyleName(ev.target.value)}
+					>
+						{BUILTIN_STYLE_KEYS.map((key) => (
+							<option key={key} value={key}>
+								{BUILTIN_STYLE_LABELS[key]}
+							</option>
+						))}
+						{e.customStyles.map((s) => (
+							<option key={s.name} value={s.name}>
+								{s.name}
+							</option>
+						))}
+					</select>
+				</label>
 				<a
 					href="#"
 					onClick={(ev) => {
@@ -271,9 +268,114 @@ function SettingsPopup({ layerConfig: e }: { layerConfig: LayerConfig }) {
 	);
 }
 
+const MAP_TYPE_PREVIEW_STATIC: Partial<Record<MapTypeKey, string>> = {
+	satellite: "https://mts1.googleapis.com/vt?hl=en-US&lyrs=s&x=0&y=0&z=0",
+	osm: "https://tile.openstreetmap.org/0/0/0.png",
+};
+
+const MAP_TYPES: MapTypeKey[] = ["map", "satellite", "osm"];
+
+function BasemapSelector({
+	previewUrls,
+	selected,
+	onSelect,
+}: {
+	previewUrls: Record<MapTypeKey, string>;
+	selected: MapTypeKey;
+	onSelect: (type: MapTypeKey) => void;
+}) {
+	return (
+		<div className="map-type-control__basemap">
+			{MAP_TYPES.map((t) => (
+				<button
+					key={t}
+					type="button"
+					className="map-type-control__button"
+					data-state={selected === t ? "on" : "off"}
+					onClick={() => onSelect(t)}
+				>
+					<div className="map-type-control__background">
+						<img src={previewUrls[t]} alt="" draggable={false} />
+					</div>
+					<span>{MAP_TYPE_LABELS[t]}</span>
+				</button>
+			))}
+		</div>
+	);
+}
+
+/** Collapse to a single menu button when the expanded basemap would overlap top-right controls. */
+function useMapTypeCompact(
+	containerRef: RefObject<HTMLDivElement | null>,
+	basemapMeasureRef: RefObject<HTMLDivElement | null>,
+) {
+	const [compact, setCompact] = useState(false);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		const measure = basemapMeasureRef.current;
+		if (!el) return;
+		const root = el.closest(".embed-controls");
+		const leftGroup = el.closest(".embed-controls__control");
+		if (!root || !leftGroup) return;
+
+		const check = () => {
+			const basemapWidth = measure?.scrollWidth ?? 0;
+			if (basemapWidth === 0) return;
+
+			const rootRect = root.getBoundingClientRect();
+			const leftEdge = rootRect.left + 8;
+			const topBandBottom = rootRect.top + 52;
+			let conflictLeft = rootRect.right - 8;
+
+			for (const control of Array.from(root.querySelectorAll(".embed-controls__control"))) {
+				if (control === leftGroup) continue;
+				const rect = control.getBoundingClientRect();
+				if (rect.top >= topBandBottom || rect.bottom <= rootRect.top) continue;
+				if (rect.left > leftEdge + 80) {
+					conflictLeft = Math.min(conflictLeft, rect.left);
+				}
+			}
+
+			let siblingsWidth = 0;
+			for (const child of Array.from(leftGroup.children)) {
+				if (child !== el && child instanceof HTMLElement) {
+					siblingsWidth += child.getBoundingClientRect().width;
+				}
+			}
+
+			const available = conflictLeft - leftEdge - 8;
+			const needed = basemapWidth + siblingsWidth;
+			setCompact((prev) => {
+				// Hysteresis avoids flip-flopping at the breakpoint.
+				if (prev) return needed > available;
+				return needed > available + 8;
+			});
+		};
+
+		const obs = new ResizeObserver(check);
+		obs.observe(root);
+		if (measure) obs.observe(measure);
+		for (const child of Array.from(leftGroup.children)) {
+			if (child !== el && child instanceof HTMLElement) obs.observe(child);
+		}
+		check();
+		return () => obs.disconnect();
+	}, [containerRef, basemapMeasureRef]);
+
+	return compact;
+}
+
 export function MapTypeDropdown({ layerConfig }: { layerConfig: LayerConfig }) {
 	const [isOpen, setIsOpen] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const basemapMeasureRef = useRef<HTMLDivElement>(null);
+	const compact = useMapTypeCompact(containerRef, basemapMeasureRef);
+	const mapPreviewUrl = useMemo(() => buildTileUrl(createRoadmapTileConfig(), 0, 0, 0), []);
+
+	useEffect(() => {
+		setIsOpen(false);
+	}, [compact]);
 
 	useEffect(() => {
 		if (!isOpen) return;
@@ -286,41 +388,79 @@ export function MapTypeDropdown({ layerConfig }: { layerConfig: LayerConfig }) {
 		return () => document.removeEventListener("mousedown", handler);
 	}, [isOpen]);
 
+	const previewUrls: Record<MapTypeKey, string> = {
+		map: mapPreviewUrl,
+		satellite: MAP_TYPE_PREVIEW_STATIC.satellite!,
+		osm: MAP_TYPE_PREVIEW_STATIC.osm!,
+	};
+
+	const settingsPopup = isOpen && (
+		<div
+			className="settings-popup"
+			style={{
+				position: "absolute",
+				top: "100%",
+				left: 0,
+				zIndex: 3,
+				maxHeight: "calc(100vh - 80px)",
+				overflowY: "auto",
+			}}
+		>
+			{compact && (
+				<BasemapSelector
+					previewUrls={previewUrls}
+					selected={layerConfig.basemap}
+					onSelect={(t) => layerConfig.setBasemap(t)}
+				/>
+			)}
+			<SettingsPopup layerConfig={layerConfig} />
+		</div>
+	);
+
 	return (
 		<div
 			className="map-control map-type-control"
 			ref={containerRef}
 			style={{ position: "relative" }}
 		>
-			<button className="map-control__menu-button" onClick={() => setIsOpen(!isOpen)}>
-				{MAP_TYPE_LABELS[layerConfig.basemap]}
-			</button>
-			{isOpen && (
-				<div
-					className="settings-popup"
-					style={{
-						position: "absolute",
-						top: "100%",
-						left: 0,
-						zIndex: 3,
-						maxHeight: "calc(100vh - 80px)",
-						overflowY: "auto",
-					}}
-				>
-					<div className="map-type-control__basemap">
-						{(["map", "satellite", "osm"] as MapTypeKey[]).map((t) => (
-							<button
-								key={t}
-								className="map-type-control__button"
-								data-state={layerConfig.basemap === t ? "on" : "off"}
-								onClick={() => layerConfig.setBasemap(t)}
-							>
-								<span>{MAP_TYPE_LABELS[t]}</span>
-							</button>
-						))}
-					</div>
-					<SettingsPopup layerConfig={layerConfig} />
-				</div>
+			<div
+				ref={basemapMeasureRef}
+				className="map-type-control__basemap map-type-control__basemap--measure"
+				aria-hidden
+			>
+				<BasemapSelector
+					previewUrls={previewUrls}
+					selected={layerConfig.basemap}
+					onSelect={() => {}}
+				/>
+			</div>
+			{compact ? (
+				<>
+					<button
+						type="button"
+						className="map-control__menu-button"
+						onClick={() => setIsOpen(!isOpen)}
+					>
+						{MAP_TYPE_LABELS[layerConfig.basemap]}
+					</button>
+					{settingsPopup}
+				</>
+			) : (
+				<>
+					<BasemapSelector
+						previewUrls={previewUrls}
+						selected={layerConfig.basemap}
+						onSelect={(t) => {
+							if (layerConfig.basemap === t) {
+								setIsOpen((v) => !v);
+							} else {
+								layerConfig.setBasemap(t);
+								setIsOpen(false);
+							}
+						}}
+					/>
+					{settingsPopup}
+				</>
 			)}
 		</div>
 	);

--- a/app/src/components/editor/tags/ApplyFieldAsTagsDialog.tsx
+++ b/app/src/components/editor/tags/ApplyFieldAsTagsDialog.tsx
@@ -117,6 +117,7 @@ export function ApplyFieldAsTagsDialog({
 							className="nselect nselect--compact"
 							value={field}
 							onChange={(e) => handleFieldChange(e.target.value)}
+							onWheel={(e) => e.stopPropagation()}
 							style={{ flex: 1 }}
 							autoFocus
 						>

--- a/app/src/components/editor/tags/ApplyFieldAsTagsDialog.tsx
+++ b/app/src/components/editor/tags/ApplyFieldAsTagsDialog.tsx
@@ -117,7 +117,6 @@ export function ApplyFieldAsTagsDialog({
 							className="nselect nselect--compact"
 							value={field}
 							onChange={(e) => handleFieldChange(e.target.value)}
-							onWheel={(e) => e.stopPropagation()}
 							style={{ flex: 1 }}
 							autoFocus
 						>

--- a/app/src/lib/geo/mapStack.ts
+++ b/app/src/lib/geo/mapStack.ts
@@ -4,7 +4,9 @@ import {
 	buildStyledTileUrl,
 	createRoadmapTileConfig,
 	createLegacyTileConfig,
+	createLegacyTerrainTileConfig,
 	createLabelsTileConfig,
+	createSatelliteLabelsTileConfig,
 	createSatelliteTileConfig,
 	createSvTileConfig,
 	createSvBlobbyTileConfig,
@@ -73,7 +75,7 @@ export function mapStackOptsFromPrefs(
 export function buildMapStack(opts: MapStackOpts): MapStackResult {
 	const tileSize = new google.maps.Size(256, 256);
 	const layers: google.maps.ImageMapType[] = [];
-	const legacyBase = opts.style === "legacy" && opts.type === "map" && !opts.terrain;
+	const legacyMap = opts.style === "legacy" && opts.type === "map";
 
 	const extraStyles: MapStyle[] = [];
 	const builtinStyles = BUILTIN_STYLE_MAP[opts.style as keyof typeof BUILTIN_STYLE_MAP];
@@ -133,24 +135,38 @@ export function buildMapStack(opts: MapStackOpts): MapStackResult {
 		);
 	} else {
 		if (opts.terrain) {
-			const cfg = createTerrainBasemapTileConfig([
-				{ elementType: "labels", stylers: [{ visibility: "off" }] },
-				{
-					elementType: "geometry.stroke",
-					featureType: "administrative",
-					stylers: [{ visibility: "off" }],
-				},
-				...extraStyles,
-			]);
-			layers.push(
-				new google.maps.ImageMapType({
-					getTileUrl: (coord: TileCoord, zoom: number) => buildTileUrl(cfg, coord.x, coord.y, zoom),
-					tileSize,
-					minZoom: 0,
-					maxZoom: 20,
-				}),
-			);
-		} else if (legacyBase) {
+			if (legacyMap) {
+				const cfg = createLegacyTerrainTileConfig();
+				layers.push(
+					new google.maps.ImageMapType({
+						getTileUrl: (coord: TileCoord, zoom: number) =>
+							buildStyledTileUrl(cfg, LEGACY_STYLE_MAP_ID, coord.x, coord.y, zoom),
+						tileSize,
+						minZoom: 0,
+						maxZoom: 20,
+					}),
+				);
+			} else {
+				const cfg = createTerrainBasemapTileConfig([
+					{ elementType: "labels", stylers: [{ visibility: "off" }] },
+					{
+						elementType: "geometry.stroke",
+						featureType: "administrative",
+						stylers: [{ visibility: "off" }],
+					},
+					...extraStyles,
+				]);
+				layers.push(
+					new google.maps.ImageMapType({
+						getTileUrl: (coord: TileCoord, zoom: number) =>
+							buildTileUrl(cfg, coord.x, coord.y, zoom),
+						tileSize,
+						minZoom: 0,
+						maxZoom: 20,
+					}),
+				);
+			}
+		} else if (legacyMap) {
 			const cfg = createLegacyTileConfig(extraStyles);
 			layers.push(
 				new google.maps.ImageMapType({
@@ -199,7 +215,9 @@ export function buildMapStack(opts: MapStackOpts): MapStackResult {
 	layers.push(svLayer);
 
 	if (opts.labels && opts.type !== "osm") {
-		const labelCfg = createLabelsTileConfig(extraStyles);
+		const labelCfg =
+			opts.type === "satellite"
+				? createSatelliteLabelsTileConfig(extraStyles) : createLabelsTileConfig(extraStyles);
 		layers.push(
 			new google.maps.ImageMapType({
 				getTileUrl: (coord: TileCoord, zoom: number) =>

--- a/app/src/lib/geo/mapStack.ts
+++ b/app/src/lib/geo/mapStack.ts
@@ -151,14 +151,7 @@ export function buildMapStack(opts: MapStackOpts): MapStackResult {
 				}),
 			);
 		} else if (legacyBase) {
-			// Legacy style renders labels in the base tile (toggled via stylers),
-			// so the separate labels layer is skipped below.
-			const cfg = createLegacyTileConfig([
-				...(opts.labels
-					? []
-					: [{ elementType: "labels", stylers: [{ visibility: "off" }] } as MapStyle]),
-				...extraStyles,
-			]);
+			const cfg = createLegacyTileConfig(extraStyles);
 			layers.push(
 				new google.maps.ImageMapType({
 					getTileUrl: (coord: TileCoord, zoom: number) =>
@@ -205,7 +198,7 @@ export function buildMapStack(opts: MapStackOpts): MapStackResult {
 	svLayer.setOpacity(blobbySingleType ? opts.svOpacity * 0.6 : opts.svOpacity);
 	layers.push(svLayer);
 
-	if (opts.labels && opts.type !== "osm" && !legacyBase) {
+	if (opts.labels && opts.type !== "osm") {
 		const labelCfg = createLabelsTileConfig(extraStyles);
 		layers.push(
 			new google.maps.ImageMapType({

--- a/app/src/lib/geo/tiles.ts
+++ b/app/src/lib/geo/tiles.ts
@@ -302,6 +302,12 @@ class Layer {
 	set layerName(v) {
 		this._a[1] = v;
 	}
+	get layerVersion() {
+		return this._a[2];
+	}
+	set layerVersion(v) {
+		this._a[2] = v;
+	}
 	get layerOptions(): LayerOption[] {
 		return (this._a[3] ??= []).map((e: any) => new LayerOption(e));
 	}
@@ -318,6 +324,7 @@ class Layer {
 function serializeLayer(e: any[], t: string[]) {
 	if (e[0] != null) t.push(`1e${e[0]}`);
 	if (e[1] != null) t.push(`2s${pbEscape(e[1])}`);
+	if (e[2] != null) t.push(`3i${e[2]}`);
 	e[3]?.forEach((e: any) => {
 		pbMsg(4, serializeLayerOption, e, t);
 	});
@@ -410,6 +417,12 @@ class Options {
 	set region(v) {
 		this._a[2] = v;
 	}
+	get outputFormat() {
+		return this._a[3] ?? 0;
+	}
+	set outputFormat(v) {
+		this._a[3] = v;
+	}
 	get unknownStyleFlag() {
 		return this._a[4] ?? 0;
 	}
@@ -434,6 +447,7 @@ function serializeOptions(e: any[], t: string[]) {
 	e[11]?.forEach((e: any) => {
 		pbMsg(12, serializeStyler, e, t);
 	});
+	if (e[3] != null) t.push(`4e${e[3]}`);
 }
 
 class RenderOptions {
@@ -506,9 +520,27 @@ export class TileConfig {
 	set renderOptions(v: any) {
 		this._a[4] = v == null ? [] : (v instanceof RenderOptions ? v : new RenderOptions(v)).toArray();
 	}
+	get tileHash() {
+		return this._a[22];
+	}
+	set tileHash(v) {
+		this._a[22] = v;
+	}
+	get footerStyleTypes(): number[] {
+		return this._a[25] ?? [];
+	}
+	set footerStyleTypes(v: number[]) {
+		this._a[25] = v;
+	}
 	toArray() {
 		return this._a;
 	}
+}
+
+function serializeTileFooterStyles(e: any[], t: string[]) {
+	e.forEach((v: number) => {
+		if (v != null) t.push(`1e${v}`);
+	});
 }
 
 function serializeTileConfig(e: any[], t: string[]) {
@@ -519,6 +551,8 @@ function serializeTileConfig(e: any[], t: string[]) {
 	if (e[2] != null) pbMsg(3, serializeOptions, e[2], t);
 	if (e[3] != null) t.push(`4i${e[3]}`);
 	if (e[4] != null) pbMsg(5, serializeRenderOptions, e[4], t);
+	if (e[22] != null) t.push(`23i${e[22]}`);
+	if (e[25]?.length) pbMsg(26, serializeTileFooterStyles, e[25], t);
 }
 
 export function serializeTileUrl(cfg: TileConfig): string {
@@ -789,6 +823,78 @@ export function createLegacyTileConfig(styles: MapStyle[] = []): TileConfig {
 				},
 				...styles,
 			]),
+		},
+		renderOptions: { scale: devicePixelRatio },
+	});
+}
+
+const LEGACY_TERRAIN_LAYER_VERSIONS = { terrain: 725, roads: 725483392 } as const;
+const LEGACY_TERRAIN_TILE_HASH = 56565656;
+
+export function createLegacyTerrainTileConfig(): TileConfig {
+	return new TileConfig({
+		query: { tile: {} },
+		layers: [
+			{
+				type: LayerType.TERRAIN,
+				layerName: "t",
+				layerVersion: LEGACY_TERRAIN_LAYER_VERSIONS.terrain,
+			},
+			{
+				type: LayerType.ROADMAP,
+				layerName: "r",
+				layerVersion: LEGACY_TERRAIN_LAYER_VERSIONS.roads,
+			},
+		],
+		options: {
+			language: "en",
+			region: "US",
+			outputFormat: 0,
+			unknownStyleFlag: LegacyFlag.LEGACY,
+			styles: [
+				new Styler({
+					type: StyleType.NO_LABELS,
+					params: [{ key: "set", value: "Terrain" }],
+				}),
+				new Styler({ type: StyleType.SMARTMAPS, params: [{ key: "smartmaps" }] }),
+			],
+		},
+		renderOptions: { rasterType: 3, scale: devicePixelRatio },
+		tileHash: LEGACY_TERRAIN_TILE_HASH,
+		footerStyleTypes: [StyleType.HIGH_DPI, StyleType.NO_LABELS],
+	});
+}
+
+export function createSatelliteLabelsTileConfig(styles: MapStyle[] = []): TileConfig {
+	const stylers: Styler[] = [
+		new Styler({ type: StyleType.SATELLITE, params: [] }),
+		new Styler({ type: StyleType.HIGH_DPI, params: [] }),
+	];
+	if (styles.length > 0) {
+		const encoded = serializeStyles([
+			{ elementType: "geometry", stylers: [{ visibility: "off" }] },
+			{
+				featureType: "administrative",
+				elementType: "geometry.stroke",
+				stylers: [{ visibility: "on" }],
+			},
+			{ elementType: "labels", stylers: [{ visibility: "on" }] },
+			...styles,
+		]);
+		if (encoded)
+			stylers.push(
+				new Styler({ type: StyleType.STYLERS, params: [{ key: "styles", value: encoded }] }),
+			);
+	}
+	return new TileConfig({
+		query: { tile: {} },
+		layers: [{ type: LayerType.ROADMAP, layerName: "m", layerOptions: [] }],
+		options: {
+			language: "en",
+			region: "US",
+			outputFormat: 0,
+			unknownStyleFlag: LegacyFlag.CURRENT,
+			styles: stylers,
 		},
 		renderOptions: { scale: devicePixelRatio },
 	});

--- a/app/src/lib/geo/tiles.ts
+++ b/app/src/lib/geo/tiles.ts
@@ -757,6 +757,22 @@ export function createLabelsTileConfig(styles: MapStyle[] = []): TileConfig {
 // The colors come from the map_id, so configs must be served via buildStyledTileUrl.
 export const LEGACY_STYLE_MAP_ID = "61449c20e7fc278b";
 
+function buildLegacyStylers(styleType: number, styles: MapStyle[] = []): Styler[] {
+	const stylers: Styler[] = [
+		new Styler({ type: styleType, params: [] }),
+		new Styler({ type: StyleType.HIGH_DPI, params: [] }),
+	];
+	if (styles.length > 0) {
+		const encoded = serializeStyles(styles);
+		if (encoded)
+			stylers.push(
+				new Styler({ type: StyleType.STYLERS, params: [{ key: "styles", value: encoded }] }),
+			);
+	}
+	return stylers;
+}
+
+// Legacy basemap via map_id with NO_LABELS so labels/borders can be stacked above SV coverage.
 export function createLegacyTileConfig(styles: MapStyle[] = []): TileConfig {
 	return new TileConfig({
 		query: { tile: {} },
@@ -764,8 +780,15 @@ export function createLegacyTileConfig(styles: MapStyle[] = []): TileConfig {
 		options: {
 			language: "en",
 			region: "US",
-			unknownStyleFlag: LegacyFlag.LEGACY,
-			styles: buildMapStyles("roadmap", styles),
+			unknownStyleFlag: LegacyFlag.CURRENT,
+			styles: buildLegacyStylers(StyleType.NO_LABELS, [
+				{
+					elementType: "geometry.stroke",
+					featureType: "administrative",
+					stylers: [{ visibility: "off" }],
+				},
+				...styles,
+			]),
 		},
 		renderOptions: { scale: devicePixelRatio },
 	});

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1744,6 +1744,10 @@ summary.button {
 .nselect--compact::picker(select) {
 	max-height: 300px;
 }
+.nselect--limited::picker(select) {
+	max-height: 150px !important;
+	scrollbar-width: thin;
+}
 .nselect:not(:disabled) {
 	cursor: pointer;
 }
@@ -2224,6 +2228,16 @@ summary.button {
 .map-type-control {
 	padding: 0;
 }
+.map-type-control__basemap--measure {
+	position: fixed;
+	left: -9999px;
+	top: 0;
+	visibility: hidden;
+	pointer-events: none;
+	width: max-content;
+	height: auto;
+	overflow: visible;
+}
 .map-type-control__basemap {
 	grid-auto-flow: column;
 	display: grid;
@@ -2239,6 +2253,7 @@ summary.button {
 	border: none;
 	font-family: Roboto, Arial, sans-serif;
 	font-size: 18px;
+	height: 40px;
 	line-height: 40px;
 	position: relative;
 	overflow: hidden;
@@ -2248,15 +2263,24 @@ summary.button {
 }
 .map-type-control__button span {
 	margin: 0 1rem;
+	position: relative;
 }
 .map-type-control__background {
 	opacity: 0.4;
-	z-index: -1;
-	width: 200px;
-	height: 40px;
+	z-index: 0;
 	position: absolute;
+	inset: 0;
+	overflow: hidden;
+}
+.map-type-control__background img {
+	position: absolute;
+	width: 256px;
+	height: 256px;
+	top: 50%;
 	left: 50%;
-	transform: translate(-50%);
+	transform: translate(-50%, -50%);
+	pointer-events: none;
+	user-select: none;
 }
 .layer-config {
 	width: 100%;
@@ -2364,7 +2388,7 @@ summary.button {
 	padding: 0;
 }
 .search-control__input {
-	width: 260px;
+	width: 210px;
 	height: 40px;
 	font: 0.9rem var(--google-maps-font);
 	border: none;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1698,6 +1698,7 @@ summary.button {
 }
 .nselect::picker(select) {
 	appearance: base-select;
+	overscroll-behavior: contain;
 }
 .nselect {
 	text-align: left;

--- a/app/test/unit/mapStack.test.ts
+++ b/app/test/unit/mapStack.test.ts
@@ -64,8 +64,12 @@ describe("buildMapStack layer composition", () => {
 		expect(layersOf(buildMapStack({ ...base, type: "osm" }))).toHaveLength(2);
 	});
 
-	it("legacy base map folds labels into the base tile (no separate labels layer)", () => {
-		expect(layersOf(buildMapStack({ ...base, style: "legacy" }))).toHaveLength(2);
+	it("legacy base map stacks a separate labels layer above SV coverage", () => {
+		expect(layersOf(buildMapStack({ ...base, style: "legacy" }))).toHaveLength(3);
+	});
+
+	it("legacy with labels off drops the labels layer", () => {
+		expect(layersOf(buildMapStack({ ...base, style: "legacy", labels: false }))).toHaveLength(2);
 	});
 
 	it("carries svOpacity onto the SV layer", () => {

--- a/app/test/unit/tiles.test.ts
+++ b/app/test/unit/tiles.test.ts
@@ -13,7 +13,9 @@ beforeAll(() => {
 describe("Legacy style tiles", () => {
 	it("serializes to the no-labels pb shape the mapsresources endpoint accepts", () => {
 		// Uses StyleType.NO_LABELS + map_id so labels can be stacked above SV coverage.
-		const url = new URL(buildStyledTileUrl(createLegacyTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6));
+		const url = new URL(
+			buildStyledTileUrl(createLegacyTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6),
+		);
 		expect(url.origin + url.pathname).toBe("https://mapsresources-pa.googleapis.com/v1/tiles");
 		expect(url.searchParams.get("map_id")).toBe(LEGACY_STYLE_MAP_ID);
 		expect(url.searchParams.get("pb")).toBe(
@@ -40,7 +42,7 @@ describe("Legacy style tiles", () => {
 			buildStyledTileUrl(createLabelsTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6),
 		);
 		expect(url.searchParams.get("pb")).toBe(
-			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on!5m1!5f1",
+			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m17!2sen!3sUS!5e1105!12m4!1e68!2m2!1sset!2sRoadmap!12m3!1e37!2m1!1ssmartmaps!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on!5m1!5f1",
 		);
 	});
 
@@ -66,12 +68,14 @@ describe("Legacy style tiles", () => {
 			),
 		);
 		expect(url.searchParams.get("pb")).toBe(
-			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on,s.t:17|s.e:g.s|p.w:2,s.t:18|s.e:g.s|p.w:3!5m1!5f1",
+			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m17!2sen!3sUS!5e1105!12m4!1e68!2m2!1sset!2sRoadmap!12m3!1e37!2m1!1ssmartmaps!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on,s.t:17|s.e:g.s|p.w:2,s.t:18|s.e:g.s|p.w:3!5m1!5f1",
 		);
 	});
 
 	it("wraps x across the antimeridian", () => {
-		const url = new URL(buildStyledTileUrl(createLegacyTileConfig(), LEGACY_STYLE_MAP_ID, -1, 0, 2));
+		const url = new URL(
+			buildStyledTileUrl(createLegacyTileConfig(), LEGACY_STYLE_MAP_ID, -1, 0, 2),
+		);
 		expect(url.searchParams.get("pb")).toContain("!1i2!2i3!3i0");
 	});
 });

--- a/app/test/unit/tiles.test.ts
+++ b/app/test/unit/tiles.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import {
 	buildStyledTileUrl,
 	createLegacyTileConfig,
+	createLegacyLabelsTileConfig,
 	LEGACY_STYLE_MAP_ID,
 } from "@/lib/geo/tiles";
 
@@ -10,24 +11,62 @@ beforeAll(() => {
 });
 
 describe("Legacy style tiles", () => {
-	it("serializes to the exact pb shape the mapsresources endpoint accepts", () => {
-		// Verified live against mapsresources-pa (2026-06-11): this pb returns the
-		// legacy-styled tile. Any drift here likely breaks the Legacy map style.
+	it("serializes to the no-labels pb shape the mapsresources endpoint accepts", () => {
+		// Uses StyleType.NO_LABELS + map_id so labels can be stacked above SV coverage.
 		const url = new URL(buildStyledTileUrl(createLegacyTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6));
 		expect(url.origin + url.pathname).toBe("https://mapsresources-pa.googleapis.com/v1/tiles");
 		expect(url.searchParams.get("map_id")).toBe(LEGACY_STYLE_MAP_ID);
 		expect(url.searchParams.get("pb")).toBe(
-			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e18!12m4!1e68!2m2!1sset!2sRoadmap!12m3!1e37!2m1!1ssmartmaps!5m1!5f1",
+			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.t:1|s.e:g.s|p.v:off!5m1!5f1",
 		);
 	});
 
-	it("composes extra stylers (labels toggle rides the base tile)", () => {
+	it("composes extra stylers on the legacy base tile", () => {
 		const cfg = createLegacyTileConfig([
-			{ elementType: "labels", stylers: [{ visibility: "off" }] },
+			{
+				featureType: "administrative.country",
+				elementType: "geometry.stroke",
+				stylers: [{ weight: 2 }],
+			},
 		]);
 		const url = new URL(buildStyledTileUrl(cfg, LEGACY_STYLE_MAP_ID, 33, 22, 6));
 		expect(url.searchParams.get("pb")).toBe(
-			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m17!2sen!3sUS!5e18!12m4!1e68!2m2!1sset!2sRoadmap!12m3!1e37!2m1!1ssmartmaps!12m4!1e26!2m2!1sstyles!2ss.e:l|p.v:off!5m1!5f1",
+			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.t:1|s.e:g.s|p.v:off,s.t:17|s.e:g.s|p.w:2!5m1!5f1",
+		);
+	});
+
+	it("serializes a legacy labels overlay tile", () => {
+		const url = new URL(
+			buildStyledTileUrl(createLegacyLabelsTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6),
+		);
+		expect(url.searchParams.get("pb")).toBe(
+			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on!5m1!5f1",
+		);
+	});
+
+	it("composes border emphasis on the legacy labels overlay tile", () => {
+		const url = new URL(
+			buildStyledTileUrl(
+				createLegacyLabelsTileConfig([
+					{
+						featureType: "administrative.country",
+						elementType: "geometry.stroke",
+						stylers: [{ weight: 2 }],
+					},
+					{
+						featureType: "administrative.province",
+						elementType: "geometry.stroke",
+						stylers: [{ weight: 3 }],
+					},
+				]),
+				LEGACY_STYLE_MAP_ID,
+				33,
+				22,
+				6,
+			),
+		);
+		expect(url.searchParams.get("pb")).toBe(
+			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on,s.t:17|s.e:g.s|p.w:2,s.t:18|s.e:g.s|p.w:3!5m1!5f1",
 		);
 	});
 

--- a/app/test/unit/tiles.test.ts
+++ b/app/test/unit/tiles.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import {
 	buildStyledTileUrl,
 	createLegacyTileConfig,
-	createLegacyLabelsTileConfig,
+	createLabelsTileConfig,
 	LEGACY_STYLE_MAP_ID,
 } from "@/lib/geo/tiles";
 
@@ -37,7 +37,7 @@ describe("Legacy style tiles", () => {
 
 	it("serializes a legacy labels overlay tile", () => {
 		const url = new URL(
-			buildStyledTileUrl(createLegacyLabelsTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6),
+			buildStyledTileUrl(createLabelsTileConfig(), LEGACY_STYLE_MAP_ID, 33, 22, 6),
 		);
 		expect(url.searchParams.get("pb")).toBe(
 			"!1m5!1m4!1i6!2i33!3i22!4i256!2m2!1e0!2sm!3m12!2sen!3sUS!5e1105!12m1!1e3!12m1!1e2!12m4!1e26!2m2!1sstyles!2ss.e:g|p.v:off,s.t:1|s.e:g.s|p.v:on,s.e:l|p.v:on!5m1!5f1",
@@ -47,7 +47,7 @@ describe("Legacy style tiles", () => {
 	it("composes border emphasis on the legacy labels overlay tile", () => {
 		const url = new URL(
 			buildStyledTileUrl(
-				createLegacyLabelsTileConfig([
+				createLabelsTileConfig([
 					{
 						featureType: "administrative.country",
 						elementType: "geometry.stroke",


### PR DESCRIPTION
Refactor basemap UI and legacy tile handling. Replace radio list with a select and add a visual BasemapSelector with compact/responsive behavior; add measurement DOM/CSS to avoid layout overlap. Improve styles (preview image positioning, limited select height, map control sizing, search input width). Use pointer events for FullscreenMiniMap and stop wheel propagation on compact selects to avoid unwanted scrolling. Change legacy tile config to serve a NO_LABELS base (buildLegacyStylers) so labels can be stacked as a separate overlay; mapStack now adds the labels layer for legacy style unless labels are disabled. Update unit tests to match new pb shapes and layer counts.