### PR TITLE
feat(editor): improve fullscreen map mode with mini preview and synced shortcuts

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -97,6 +97,7 @@ function AppChrome() {
 	});
 
 	const hasSeenWelcome = useSetting("hasSeenWelcome");
+	const fullscreenMap = useSetting("fullscreenMap");
 
 	return (
 		<>
@@ -122,7 +123,7 @@ function AppChrome() {
 				open={!map && !hasSeenWelcome}
 				onDismiss={() => setSetting("hasSeenWelcome", true)}
 			/>
-			{!showSettings && !showPlugins && (
+			{!showSettings && !showPlugins && !(map && fullscreenMap) && (
 				<div
 					className="bottom-bar"
 					style={{ position: "fixed", bottom: 12, right: 12, zIndex: 5, display: "flex", gap: 4 }}

--- a/app/src/components/dialogs/SettingsPage.tsx
+++ b/app/src/components/dialogs/SettingsPage.tsx
@@ -810,6 +810,14 @@ function FullscreenMapSection() {
 				/>
 				Show map meta bar in fullscreen
 			</label>
+			<label className="settings-popup__item">
+				<input
+					type="checkbox"
+					checked={s.showFullscreenMiniLocationPreview}
+					onChange={(e) => setSetting("showFullscreenMiniLocationPreview", e.target.checked)}
+				/>
+				Show mini location preview in fullscreen map
+			</label>
 		</fieldset>
 	);
 }

--- a/app/src/components/dialogs/SettingsPage.tsx
+++ b/app/src/components/dialogs/SettingsPage.tsx
@@ -795,9 +795,29 @@ function ControlsTab() {
 	);
 }
 
+function FullscreenMapSection() {
+	const s = useSettings();
+	return (
+		<fieldset className="fieldset">
+			<legend className="fieldset__header">
+				Fullscreen<span className="fieldset__divider" />
+			</legend>
+			<label className="settings-popup__item">
+				<input
+					type="checkbox"
+					checked={s.showFullscreenMapMeta}
+					onChange={(e) => setSetting("showFullscreenMapMeta", e.target.checked)}
+				/>
+				Show map meta bar in fullscreen
+			</label>
+		</fieldset>
+	);
+}
+
 function MapTab() {
 	return (
 		<>
+			<FullscreenMapSection />
 			<MapNavigationSection />
 			<MarkersSection />
 			<PanoDotsSection />

--- a/app/src/components/dialogs/SettingsPage.tsx
+++ b/app/src/components/dialogs/SettingsPage.tsx
@@ -816,7 +816,7 @@ function FullscreenMapSection() {
 					checked={s.showFullscreenMiniLocationPreview}
 					onChange={(e) => setSetting("showFullscreenMiniLocationPreview", e.target.checked)}
 				/>
-				Show mini location preview in fullscreen map
+				Show mini location preview in fullscreen
 			</label>
 		</fieldset>
 	);

--- a/app/src/components/editor/MapEditor.tsx
+++ b/app/src/components/editor/MapEditor.tsx
@@ -30,6 +30,7 @@ import { MapOverview } from "@/components/editor/map/MapOverview";
 import { ImportSidebar } from "@/components/editor/ImportSidebar";
 import { DiffSidebar } from "@/components/editor/DiffSidebar";
 import { LocationPreview } from "@/components/editor/location/LocationPreview";
+import { FullscreenMiniLocationPreview } from "@/components/editor/location/FullscreenMiniLocationPreview";
 import { CommandPalette } from "@/components/editor/CommandPalette";
 import { MapRenameForm } from "@/components/editor/MapRenameForm";
 import { EnrichmentButton } from "@/components/editor/map/EnrichmentDialog";
@@ -383,6 +384,9 @@ export function MapEditor() {
 			<section className="map-embed" style={{ background: "#e5e3df" }}>
 				<MapEmbed onAddLocation={(p) => addParsedLocations([p])} />
 				{showMapCursor && <div className="map-cursor-crosshair" />}
+				{appSettings.fullscreenMap &&
+					appSettings.showFullscreenMiniLocationPreview &&
+					workArea === "location" && <FullscreenMiniLocationPreview />}
 			</section>
 			{(!appSettings.fullscreenMap || appSettings.showFullscreenMapMeta) && (
 				<section className="map-meta">

--- a/app/src/components/editor/MapEditor.tsx
+++ b/app/src/components/editor/MapEditor.tsx
@@ -32,6 +32,7 @@ import { DiffSidebar } from "@/components/editor/DiffSidebar";
 import { LocationPreview } from "@/components/editor/location/LocationPreview";
 import { FullscreenMiniLocationPreview } from "@/components/editor/location/FullscreenMiniLocationPreview";
 import { PanoViewerProvider } from "@/components/editor/location/PanoViewerContext";
+import { exitFullscreenMap } from "@/components/editor/location/fullscreenModeState";
 import { useFullscreenModeHotkeys } from "@/components/editor/location/useFullscreenModeHotkeys";
 import { CommandPalette } from "@/components/editor/CommandPalette";
 import { MapRenameForm } from "@/components/editor/MapRenameForm";
@@ -293,7 +294,7 @@ export function MapEditor() {
 	useHotkey(
 		"escape",
 		() => {
-			if (getSettings().fullscreenMap) setSetting("fullscreenMap", false);
+			exitFullscreenMap();
 		},
 		{ bubble: true },
 	);

--- a/app/src/components/editor/MapEditor.tsx
+++ b/app/src/components/editor/MapEditor.tsx
@@ -31,6 +31,8 @@ import { ImportSidebar } from "@/components/editor/ImportSidebar";
 import { DiffSidebar } from "@/components/editor/DiffSidebar";
 import { LocationPreview } from "@/components/editor/location/LocationPreview";
 import { FullscreenMiniLocationPreview } from "@/components/editor/location/FullscreenMiniLocationPreview";
+import { PanoViewerProvider } from "@/components/editor/location/PanoViewerContext";
+import { useFullscreenModeHotkeys } from "@/components/editor/location/useFullscreenModeHotkeys";
 import { CommandPalette } from "@/components/editor/CommandPalette";
 import { MapRenameForm } from "@/components/editor/MapRenameForm";
 import { EnrichmentButton } from "@/components/editor/map/EnrichmentDialog";
@@ -234,6 +236,11 @@ function SplitHandle({ onSplitChange }: { onSplitChange: (v: number) => void }) 
 	);
 }
 
+function FullscreenModeHotkeys() {
+	useFullscreenModeHotkeys();
+	return null;
+}
+
 export function MapEditor() {
 	const map = useCurrentMap();
 	const workArea = useWorkArea();
@@ -283,9 +290,6 @@ export function MapEditor() {
 	useMapKeyBindings(() => getCurrentMap()?.meta.settings.keyBindings ?? []);
 	useCountrySelect();
 	useDeletePolygon();
-	useHotkey(useBinding("toggleFullscreenMap"), () => {
-		setSetting("fullscreenMap", !getSettings().fullscreenMap);
-	});
 	useHotkey(
 		"escape",
 		() => {
@@ -342,14 +346,16 @@ export function MapEditor() {
 	const editorClasses = `page-map-editor${appSettings.fullscreenMap ? " fullscreen-map" : ""}`;
 
 	return (
-		<div
-			className={editorClasses}
-			style={{
-				gridTemplateColumns: appSettings.fullscreenMap
-					? undefined
-					: `minmax(0, ${split}fr) minmax(0, ${100 - split}fr)`,
-			}}
-		>
+		<PanoViewerProvider>
+			<FullscreenModeHotkeys />
+			<div
+				className={editorClasses}
+				style={{
+					gridTemplateColumns: appSettings.fullscreenMap
+						? undefined
+						: `minmax(0, ${split}fr) minmax(0, ${100 - split}fr)`,
+				}}
+			>
 			{!appSettings.fullscreenMap && <SplitHandle onSplitChange={setSplit} />}
 			<header>
 				<Tooltip content="Back to map list" side="bottom" align="start">
@@ -406,5 +412,6 @@ export function MapEditor() {
 				</div>
 			)}
 		</div>
+		</PanoViewerProvider>
 	);
 }

--- a/app/src/components/editor/MapEditor.tsx
+++ b/app/src/components/editor/MapEditor.tsx
@@ -286,6 +286,13 @@ export function MapEditor() {
 		setSetting("fullscreenMap", !getSettings().fullscreenMap);
 	});
 	useHotkey(
+		"escape",
+		() => {
+			if (getSettings().fullscreenMap) setSetting("fullscreenMap", false);
+		},
+		{ bubble: true },
+	);
+	useHotkey(
 		useBinding("locationDelete"),
 		() => {
 			const ids = getSelectedLocationIds();
@@ -342,7 +349,7 @@ export function MapEditor() {
 					: `minmax(0, ${split}fr) minmax(0, ${100 - split}fr)`,
 			}}
 		>
-			<SplitHandle onSplitChange={setSplit} />
+			{!appSettings.fullscreenMap && <SplitHandle onSplitChange={setSplit} />}
 			<header>
 				<Tooltip content="Back to map list" side="bottom" align="start">
 					<a
@@ -377,9 +384,11 @@ export function MapEditor() {
 				<MapEmbed onAddLocation={(p) => addParsedLocations([p])} />
 				{showMapCursor && <div className="map-cursor-crosshair" />}
 			</section>
-			<section className="map-meta">
-				<MapMetaBar />
-			</section>
+			{(!appSettings.fullscreenMap || appSettings.showFullscreenMapMeta) && (
+				<section className="map-meta">
+					<MapMetaBar />
+				</section>
+			)}
 			<MapOverview hidden={workArea !== "overview"} />
 			{workArea === "location" && <LocationPreview />}
 			{workArea === "duplicates" && <SameLocation />}

--- a/app/src/components/editor/location/FullscreenMiniLocationPreview.tsx
+++ b/app/src/components/editor/location/FullscreenMiniLocationPreview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Icon } from "@/components/primitives/Icon";
 import { mdiMinus, mdiPlus } from "@mdi/js";
 import { useActiveLocation } from "@/store/useMapStore";
-import { useSetting, setSetting, getSettings } from "@/store/settings";
+import { useSetting, setSetting } from "@/store/settings";
 import { range, clamp } from "@/types/util";
 import { singletonDiv, singletonPano } from "@/lib/sv/panoSingleton";
 import { google } from "@/lib/sv/opensv";
@@ -12,6 +12,10 @@ const PREVIEW_SCALE_STEP = 0.5;
 const PREVIEW_BASE_W = 480;
 const PREVIEW_BASE_H = 270;
 const PREVIEW_CLOSE_DELAY = 500;
+
+function resizePano() {
+	if (singletonPano && google?.maps) google.maps.event.trigger(singletonPano, "resize");
+}
 
 /** Floating Street View chip for fullscreen-map mode. Reuses the singleton pano
  *  (LocationPreview yields ownership while this is mounted). No embed controls. */
@@ -28,29 +32,18 @@ export function FullscreenMiniLocationPreview() {
 		container.appendChild(singletonDiv);
 		if (singletonPano) {
 			singletonPano.setVisible(true);
-			if (google?.maps) google.maps.event.trigger(singletonPano, "resize");
+			resizePano();
 		}
 		return () => {
 			if (container.contains(singletonDiv)) container.removeChild(singletonDiv);
 		};
 	}, [location?.id]);
 
-	useEffect(() => {
-		if (!singletonPano) return;
-		singletonPano.setOptions({ linksControl: false });
-		return () => {
-			if (!singletonPano) return;
-			const noMove = getSettings().defaultMovementMode !== "moving";
-			singletonPano.setOptions({
-				linksControl: noMove ? false : getSettings().showLinksControl,
-			});
-		};
-	}, []);
-
-	useEffect(() => {
-		if (!singletonPano || !google?.maps) return;
-		google.maps.event.trigger(singletonPano, "resize");
-	}, [expanded, scale]);
+	// Size changes are not CSS-animated (avoids canvas stretch mid-transition).
+	// Resize once after layout commits — never during a transition.
+	useLayoutEffect(() => {
+		resizePano();
+	}, [expanded, scale, location?.id]);
 
 	const setScale = (next: number) => {
 		const clamped = clamp(next, PREVIEW_SCALE);

--- a/app/src/components/editor/location/FullscreenMiniLocationPreview.tsx
+++ b/app/src/components/editor/location/FullscreenMiniLocationPreview.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Icon } from "@/components/primitives/Icon";
+import { mdiMinus, mdiPlus } from "@mdi/js";
+import { useActiveLocation } from "@/store/useMapStore";
+import { useSetting, setSetting, getSettings } from "@/store/settings";
+import { range, clamp } from "@/types/util";
+import { singletonDiv, singletonPano } from "@/lib/sv/panoSingleton";
+import { google } from "@/lib/sv/opensv";
+
+const PREVIEW_SCALE = range([0.5, 2]);
+const PREVIEW_SCALE_STEP = 0.5;
+const PREVIEW_BASE_W = 480;
+const PREVIEW_BASE_H = 270;
+const PREVIEW_CLOSE_DELAY = 500;
+
+/** Floating Street View chip for fullscreen-map mode. Reuses the singleton pano
+ *  (LocationPreview yields ownership while this is mounted). No embed controls. */
+export function FullscreenMiniLocationPreview() {
+	const location = useActiveLocation();
+	const containerRef = useRef<HTMLDivElement>(null);
+	const scale = useSetting("fullscreenMiniLocationScale");
+	const [expanded, setExpanded] = useState(false);
+	const closeTimer = useRef<number | null>(null);
+
+	useLayoutEffect(() => {
+		const container = containerRef.current;
+		if (!container || !location) return;
+		container.appendChild(singletonDiv);
+		if (singletonPano) {
+			singletonPano.setVisible(true);
+			if (google?.maps) google.maps.event.trigger(singletonPano, "resize");
+		}
+		return () => {
+			if (container.contains(singletonDiv)) container.removeChild(singletonDiv);
+		};
+	}, [location?.id]);
+
+	useEffect(() => {
+		if (!singletonPano) return;
+		singletonPano.setOptions({ linksControl: false });
+		return () => {
+			if (!singletonPano) return;
+			const noMove = getSettings().defaultMovementMode !== "moving";
+			singletonPano.setOptions({
+				linksControl: noMove ? false : getSettings().showLinksControl,
+			});
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!singletonPano || !google?.maps) return;
+		google.maps.event.trigger(singletonPano, "resize");
+	}, [expanded, scale]);
+
+	const setScale = (next: number) => {
+		const clamped = clamp(next, PREVIEW_SCALE);
+		setSetting("fullscreenMiniLocationScale", Math.round(clamped * 100) / 100);
+	};
+
+	const open = () => {
+		if (closeTimer.current !== null) {
+			clearTimeout(closeTimer.current);
+			closeTimer.current = null;
+		}
+		setExpanded(true);
+	};
+	const scheduleClose = () => {
+		if (closeTimer.current !== null) clearTimeout(closeTimer.current);
+		closeTimer.current = window.setTimeout(() => {
+			setExpanded(false);
+			closeTimer.current = null;
+		}, PREVIEW_CLOSE_DELAY);
+	};
+
+	useEffect(() => {
+		return () => {
+			if (closeTimer.current !== null) clearTimeout(closeTimer.current);
+		};
+	}, []);
+
+	if (!location) return null;
+
+	const sizeVars = {
+		"--fs-mini-loc-w": `${Math.round(PREVIEW_BASE_W * scale)}px`,
+		"--fs-mini-loc-h": `${Math.round(PREVIEW_BASE_H * scale)}px`,
+	} as React.CSSProperties;
+
+	return (
+		<div
+			className={`fullscreen-mini-location${expanded ? " is-expanded" : ""}`}
+			style={sizeVars}
+			onPointerEnter={open}
+			onPointerLeave={scheduleClose}
+		>
+			<div ref={containerRef} className="fullscreen-mini-location__pano" />
+			<div className="fullscreen-mini-location__size">
+				<button
+					type="button"
+					className="fullscreen-mini-location__size-btn"
+					aria-label="Smaller location preview"
+					disabled={scale <= PREVIEW_SCALE.min}
+					onClick={() => setScale(scale - PREVIEW_SCALE_STEP)}
+				>
+					<Icon path={mdiMinus} size={16} />
+				</button>
+				<button
+					type="button"
+					className="fullscreen-mini-location__size-btn"
+					aria-label="Larger location preview"
+					disabled={scale >= PREVIEW_SCALE.max}
+					onClick={() => setScale(scale + PREVIEW_SCALE_STEP)}
+				>
+					<Icon path={mdiPlus} size={16} />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/app/src/components/editor/location/LocationPreview.tsx
+++ b/app/src/components/editor/location/LocationPreview.tsx
@@ -49,7 +49,7 @@ import {
 import { loadOpenSV, google } from "@/lib/sv/opensv";
 import { fetchSvMetadata } from "@/lib/sv/svMeta";
 
-import { useSettings, useSetting, getSettings, setSetting, GEOCODE_PROVIDER_LABELS } from "@/store/settings";
+import { useSettings, useSetting, getSettings, GEOCODE_PROVIDER_LABELS } from "@/store/settings";
 import { PluginLocationPanels } from "@/plugins/PluginPanels";
 import { relativeTime } from "@/lib/util/format";
 import { textColorFor } from "@/lib/util/color";

--- a/app/src/components/editor/location/LocationPreview.tsx
+++ b/app/src/components/editor/location/LocationPreview.tsx
@@ -61,7 +61,8 @@ import { FullscreenTagBar } from "@/components/editor/location/FullscreenTagBar"
 import { PanoControls, CrosshairOverlay, sendHideCar } from "./PanoControls";
 import { seenPanoChanged, seenFlush, seenSetCanvas, seenUpdateGeo } from "@/lib/seen/seen";
 import { useReverseGeocode, type GeoDisplay } from "@/components/editor/location/useReverseGeocode";
-import { PanoViewerProvider, usePanoViewer, setPanoAltitude } from "./PanoViewerContext";
+import { usePanoViewer, setPanoAltitude } from "./PanoViewerContext";
+import { togglePanoFullscreenState } from "./useFullscreenModeHotkeys";
 import {
 	applyViewportLock,
 	getViewportLockInfo,
@@ -208,11 +209,7 @@ const TagEditor = memo(function TagEditor({
 });
 
 export function LocationPreview() {
-	return (
-		<PanoViewerProvider>
-			<LocationPreviewInner />
-		</PanoViewerProvider>
-	);
+	return <LocationPreviewInner />;
 }
 
 function LocationPreviewInner() {
@@ -579,8 +576,8 @@ function LocationPreviewInner() {
 	}, []);
 
 	const handleFullscreen = useCallback(() => {
-		setIsFullscreen((v) => !v);
-	}, []);
+		togglePanoFullscreenState(location, isFullscreen, setIsFullscreen);
+	}, [location, isFullscreen, setIsFullscreen]);
 
 	useEffect(() => {
 		if (singletonPano && google?.maps) google.maps.event.trigger(singletonPano, "resize");
@@ -619,7 +616,6 @@ function LocationPreviewInner() {
 		handleClose,
 		handleDelete,
 		handleReturnToSpawn,
-		handleFullscreen,
 		handleDateChange,
 	});
 

--- a/app/src/components/editor/location/LocationPreview.tsx
+++ b/app/src/components/editor/location/LocationPreview.tsx
@@ -49,7 +49,7 @@ import {
 import { loadOpenSV, google } from "@/lib/sv/opensv";
 import { fetchSvMetadata } from "@/lib/sv/svMeta";
 
-import { useSettings, useSetting, getSettings, GEOCODE_PROVIDER_LABELS } from "@/store/settings";
+import { useSettings, useSetting, getSettings, setSetting, GEOCODE_PROVIDER_LABELS } from "@/store/settings";
 import { PluginLocationPanels } from "@/plugins/PluginPanels";
 import { relativeTime } from "@/lib/util/format";
 import { textColorFor } from "@/lib/util/color";
@@ -536,6 +536,10 @@ function LocationPreviewInner() {
 	const handleClose = useCallback(() => {
 		if (isFullscreen) {
 			setIsFullscreen(false);
+			return;
+		}
+		if (getSettings().fullscreenMap) {
+			setSetting("fullscreenMap", false);
 			return;
 		}
 		if (isReviewMode) {

--- a/app/src/components/editor/location/LocationPreview.tsx
+++ b/app/src/components/editor/location/LocationPreview.tsx
@@ -63,6 +63,7 @@ import { seenPanoChanged, seenFlush, seenSetCanvas, seenUpdateGeo } from "@/lib/
 import { useReverseGeocode, type GeoDisplay } from "@/components/editor/location/useReverseGeocode";
 import { usePanoViewer, setPanoAltitude } from "./PanoViewerContext";
 import { togglePanoFullscreenState } from "./useFullscreenModeHotkeys";
+import { resumeFullscreenMapAfterPano, exitFullscreenMap } from "./fullscreenModeState";
 import {
 	applyViewportLock,
 	getViewportLockInfo,
@@ -268,7 +269,7 @@ function LocationPreviewInner() {
 		if (!singletonPano) return;
 		const noMove = appSettings.defaultMovementMode !== "moving";
 		singletonPano.setOptions({
-			linksControl: yieldPanoToMini ? false : noMove ? false : appSettings.showLinksControl,
+			linksControl: noMove ? false : appSettings.showLinksControl,
 			clickToGo: noMove ? false : appSettings.clickToGo,
 			showRoadLabels: appSettings.showRoadLabels,
 			scrollwheel: appSettings.defaultMovementMode !== "nmpz",
@@ -317,6 +318,10 @@ function LocationPreviewInner() {
 
 	useEffect(() => {
 		if (!location || !panoContainerRef.current) return;
+		setPanoReady(false);
+		setCurrentPano(null);
+		if (singletonPano) singletonPano.setVisible(false);
+
 		let cancelled = false;
 		let statusListener: google.maps.MapsEventListener | null = null;
 		let lockListener: google.maps.MapsEventListener | null = null;
@@ -541,10 +546,11 @@ function LocationPreviewInner() {
 	const handleClose = useCallback(() => {
 		if (isFullscreen) {
 			setIsFullscreen(false);
+			resumeFullscreenMapAfterPano();
 			return;
 		}
 		if (getSettings().fullscreenMap) {
-			setSetting("fullscreenMap", false);
+			exitFullscreenMap(setIsFullscreen);
 			return;
 		}
 		if (isReviewMode) {

--- a/app/src/components/editor/location/LocationPreview.tsx
+++ b/app/src/components/editor/location/LocationPreview.tsx
@@ -250,6 +250,8 @@ function LocationPreviewInner() {
 		if (geoResult) seenUpdateGeo(geoResult);
 	}, [geoResult]);
 	const appSettings = useSettings();
+	const yieldPanoToMini =
+		appSettings.fullscreenMap && appSettings.showFullscreenMiniLocationPreview;
 	const bottomTrayRef = useRef<HTMLDivElement>(null);
 	const [bottomTrayHeight, setBottomTrayHeight] = useState(0);
 	useLayoutEffect(() => {
@@ -269,12 +271,13 @@ function LocationPreviewInner() {
 		if (!singletonPano) return;
 		const noMove = appSettings.defaultMovementMode !== "moving";
 		singletonPano.setOptions({
-			linksControl: noMove ? false : appSettings.showLinksControl,
+			linksControl: yieldPanoToMini ? false : noMove ? false : appSettings.showLinksControl,
 			clickToGo: noMove ? false : appSettings.clickToGo,
 			showRoadLabels: appSettings.showRoadLabels,
 			scrollwheel: appSettings.defaultMovementMode !== "nmpz",
 		});
 	}, [
+		yieldPanoToMini,
 		appSettings.showLinksControl,
 		appSettings.clickToGo,
 		appSettings.showRoadLabels,
@@ -299,16 +302,21 @@ function LocationPreviewInner() {
 	}, [appSettings.showCrosshair]);
 
 	// Mount/unmount: move the persistent div in/out of the container.
-	// useLayoutEffect so setVisible(false) + appendChild run before paint.
+	// useLayoutEffect so appendChild runs before paint.
+	// Yield to FullscreenMiniLocationPreview while fullscreen-map mode owns the chip.
 	useLayoutEffect(() => {
+		if (yieldPanoToMini) return;
 		const container = panoContainerRef.current;
 		if (!container) return;
-		if (singletonPano) singletonPano.setVisible(false);
 		container.appendChild(singletonDiv);
+		if (singletonPano) {
+			singletonPano.setVisible(true);
+			if (google?.maps) google.maps.event.trigger(singletonPano, "resize");
+		}
 		return () => {
 			if (container.contains(singletonDiv)) container.removeChild(singletonDiv);
 		};
-	}, []);
+	}, [yieldPanoToMini]);
 
 	useEffect(() => {
 		if (!location || !panoContainerRef.current) return;

--- a/app/src/components/editor/location/PanoViewerContext.tsx
+++ b/app/src/components/editor/location/PanoViewerContext.tsx
@@ -15,7 +15,7 @@ import { useTimezone } from "@/lib/util/timezone";
 import type { PanoReference } from "@/lib/sv/lookup";
 import { useExactDate } from "./useExactDate";
 import { derivePanoDateState, type PanoDateState } from "./panoDate";
-import { restoreSuspendedFullscreenMap, registerPanoFullscreenSetter, clearAllFullscreenSuspensions } from "./fullscreenModeState";
+import { restoreSuspendedFullscreenMap, registerPanoFullscreenSetter, clearSuspendedPanoFullscreen } from "./fullscreenModeState";
 
 // Altitude lives outside React: its only reader is the imperative coordinate
 // readout, so routing it through context would re-render every consumer.
@@ -99,12 +99,13 @@ export function PanoViewerProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => registerPanoFullscreenSetter(setIsFullscreen), []);
 
-	// Location cleared: drop pano fullscreen and restore whichever mode was suspended.
+	// Location cleared (save/delete/close): drop pano fullscreen and resume
+	// fullscreen-map if it was suspended. Must restore before clearing flags.
 	useEffect(() => {
 		if (location) return;
 		setIsFullscreen(false);
-		clearAllFullscreenSuspensions();
 		restoreSuspendedFullscreenMap();
+		clearSuspendedPanoFullscreen();
 	}, [location]);
 
 	const value = useMemo(

--- a/app/src/components/editor/location/PanoViewerContext.tsx
+++ b/app/src/components/editor/location/PanoViewerContext.tsx
@@ -15,6 +15,7 @@ import { useTimezone } from "@/lib/util/timezone";
 import type { PanoReference } from "@/lib/sv/lookup";
 import { useExactDate } from "./useExactDate";
 import { derivePanoDateState, type PanoDateState } from "./panoDate";
+import { restoreSuspendedFullscreenMap, registerPanoFullscreenSetter, clearAllFullscreenSuspensions } from "./fullscreenModeState";
 
 // Altitude lives outside React: its only reader is the imperative coordinate
 // readout, so routing it through context would re-render every consumer.
@@ -95,6 +96,16 @@ export function PanoViewerProvider({ children }: { children: ReactNode }) {
 		if (!loc || loc.extra?.datetime != null) return;
 		patchLocationExtra(loc, { datetime: exactDate.ts, timezone: resolvedTz });
 	}, [exactDate.ts, resolvedTz]);
+
+	useEffect(() => registerPanoFullscreenSetter(setIsFullscreen), []);
+
+	// Location cleared: drop pano fullscreen and restore whichever mode was suspended.
+	useEffect(() => {
+		if (location) return;
+		setIsFullscreen(false);
+		clearAllFullscreenSuspensions();
+		restoreSuspendedFullscreenMap();
+	}, [location]);
 
 	const value = useMemo(
 		() => ({

--- a/app/src/components/editor/location/fullscreenModeState.ts
+++ b/app/src/components/editor/location/fullscreenModeState.ts
@@ -1,0 +1,76 @@
+import { getSettings, setSetting } from "@/store/settings";
+
+/** Pano fullscreen temporarily replaced fullscreen-map mode. */
+let suspendedFullscreenMap = false;
+/** Fullscreen-map temporarily replaced pano fullscreen. */
+let suspendedPanoFullscreen = false;
+
+let setPanoFullscreenImpl: ((value: boolean) => void) | null = null;
+
+export function registerPanoFullscreenSetter(setter: (value: boolean) => void): () => void {
+	setPanoFullscreenImpl = setter;
+	return () => {
+		if (setPanoFullscreenImpl === setter) setPanoFullscreenImpl = null;
+	};
+}
+
+export function restoreSuspendedFullscreenMap(): void {
+	if (!suspendedFullscreenMap) return;
+	suspendedFullscreenMap = false;
+	setSetting("fullscreenMap", true);
+}
+
+export function clearSuspendedFullscreenMap(): void {
+	suspendedFullscreenMap = false;
+}
+
+export function suspendFullscreenMapForPano(): void {
+	if (getSettings().fullscreenMap) {
+		suspendedFullscreenMap = true;
+		setSetting("fullscreenMap", false);
+	}
+}
+
+export function resumeFullscreenMapAfterPano(): void {
+	restoreSuspendedFullscreenMap();
+}
+
+export function suspendPanoFullscreenForMap(): void {
+	suspendedPanoFullscreen = true;
+}
+
+export function clearSuspendedPanoFullscreen(): void {
+	suspendedPanoFullscreen = false;
+}
+
+export function resumePanoFullscreenAfterMap(setIsFullscreen?: (value: boolean) => void): void {
+	if (!suspendedPanoFullscreen) return;
+	suspendedPanoFullscreen = false;
+	const apply = setIsFullscreen ?? setPanoFullscreenImpl;
+	apply?.(true);
+}
+
+/** Exit fullscreen-map and restore suspended pano fullscreen when applicable. */
+export function exitFullscreenMap(setIsFullscreen?: (value: boolean) => void): void {
+	if (!getSettings().fullscreenMap) return;
+	setSetting("fullscreenMap", false);
+	resumePanoFullscreenAfterMap(setIsFullscreen);
+}
+
+export function enterFullscreenMapFromPano(isFullscreen: boolean, setIsFullscreen: (value: boolean) => void): void {
+	if (isFullscreen) {
+		suspendPanoFullscreenForMap();
+		setIsFullscreen(false);
+	}
+	setSetting("fullscreenMap", true);
+}
+
+export function exitFullscreenMapToggle(setIsFullscreen?: (value: boolean) => void): void {
+	setSetting("fullscreenMap", false);
+	resumePanoFullscreenAfterMap(setIsFullscreen);
+}
+
+export function clearAllFullscreenSuspensions(): void {
+	clearSuspendedFullscreenMap();
+	clearSuspendedPanoFullscreen();
+}

--- a/app/src/components/editor/location/useFullscreenModeHotkeys.ts
+++ b/app/src/components/editor/location/useFullscreenModeHotkeys.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import type { Location } from "@/bindings.gen";
+import { getSettings, setSetting } from "@/store/settings";
+import { useHotkey } from "@/lib/hooks/useHotkey";
+import { useBinding } from "@/lib/util/hotkeys";
+import { useActiveLocation } from "@/store/useMapStore";
+import { usePanoViewer } from "./PanoViewerContext";
+
+export function togglePanoFullscreenState(
+	location: Location | null,
+	isFullscreen: boolean,
+	setIsFullscreen: (value: boolean) => void,
+): void {
+	if (!location) return;
+	const next = !isFullscreen;
+	if (next && getSettings().fullscreenMap) setSetting("fullscreenMap", false);
+	setIsFullscreen(next);
+}
+
+export function toggleMapFullscreenState(
+	isFullscreen: boolean,
+	setIsFullscreen: (value: boolean) => void,
+): void {
+	const next = !getSettings().fullscreenMap;
+	if (next && isFullscreen) setIsFullscreen(false);
+	setSetting("fullscreenMap", next);
+}
+
+/** Keeps fullscreen-map and pano-fullscreen shortcuts in sync (entering one exits the other). */
+export function useFullscreenModeHotkeys() {
+	const location = useActiveLocation();
+	const { isFullscreen, setIsFullscreen } = usePanoViewer();
+
+	const togglePanoFullscreen = useCallback(
+		() => togglePanoFullscreenState(location, isFullscreen, setIsFullscreen),
+		[location, isFullscreen, setIsFullscreen],
+	);
+
+	const toggleMapFullscreen = useCallback(
+		() => toggleMapFullscreenState(isFullscreen, setIsFullscreen),
+		[isFullscreen, setIsFullscreen],
+	);
+
+	useHotkey(useBinding("toggleFullscreen"), togglePanoFullscreen);
+	useHotkey(useBinding("toggleFullscreenMap"), toggleMapFullscreen);
+
+	return { togglePanoFullscreen, toggleMapFullscreen };
+}

--- a/app/src/components/editor/location/useFullscreenModeHotkeys.ts
+++ b/app/src/components/editor/location/useFullscreenModeHotkeys.ts
@@ -1,10 +1,16 @@
 import { useCallback } from "react";
 import type { Location } from "@/bindings.gen";
-import { getSettings, setSetting } from "@/store/settings";
+import { getSettings } from "@/store/settings";
 import { useHotkey } from "@/lib/hooks/useHotkey";
 import { useBinding } from "@/lib/util/hotkeys";
 import { useActiveLocation } from "@/store/useMapStore";
 import { usePanoViewer } from "./PanoViewerContext";
+import {
+	enterFullscreenMapFromPano,
+	exitFullscreenMapToggle,
+	resumeFullscreenMapAfterPano,
+	suspendFullscreenMapForPano,
+} from "./fullscreenModeState";
 
 export function togglePanoFullscreenState(
 	location: Location | null,
@@ -13,7 +19,8 @@ export function togglePanoFullscreenState(
 ): void {
 	if (!location) return;
 	const next = !isFullscreen;
-	if (next && getSettings().fullscreenMap) setSetting("fullscreenMap", false);
+	if (next) suspendFullscreenMapForPano();
+	else resumeFullscreenMapAfterPano();
 	setIsFullscreen(next);
 }
 
@@ -22,8 +29,8 @@ export function toggleMapFullscreenState(
 	setIsFullscreen: (value: boolean) => void,
 ): void {
 	const next = !getSettings().fullscreenMap;
-	if (next && isFullscreen) setIsFullscreen(false);
-	setSetting("fullscreenMap", next);
+	if (next) enterFullscreenMapFromPano(isFullscreen, setIsFullscreen);
+	else exitFullscreenMapToggle(setIsFullscreen);
 }
 
 /** Keeps fullscreen-map and pano-fullscreen shortcuts in sync (entering one exits the other). */

--- a/app/src/components/editor/location/useLocationHotkeys.ts
+++ b/app/src/components/editor/location/useLocationHotkeys.ts
@@ -52,7 +52,6 @@ interface LocationHotkeyDeps {
 	handleClose: () => void;
 	handleDelete: () => void;
 	handleReturnToSpawn: () => void;
-	handleFullscreen: () => void;
 	handleDateChange: (panoId: string | null) => void;
 }
 
@@ -72,7 +71,6 @@ export function useLocationHotkeys(deps: LocationHotkeyDeps) {
 		handleClose,
 		handleDelete,
 		handleReturnToSpawn,
-		handleFullscreen,
 		handleDateChange,
 	} = deps;
 
@@ -90,9 +88,6 @@ export function useLocationHotkeys(deps: LocationHotkeyDeps) {
 	});
 	useHotkey(useBinding("reviewPrev"), () => {
 		if (isReviewMode) reviewPrev();
-	});
-	useHotkey(useBinding("toggleFullscreen"), () => {
-		handleFullscreen();
 	});
 	useHotkey(useBinding("returnToSpawn"), () => {
 		handleReturnToSpawn();

--- a/app/src/components/editor/map/MapEmbed.tsx
+++ b/app/src/components/editor/map/MapEmbed.tsx
@@ -311,6 +311,7 @@ export function MapEmbed({
 	}, []);
 
 	const showFps = useSetting("showFps");
+	const fullscreenMap = useSetting("fullscreenMap");
 
 	useHotkey(useBinding("mapZoomReset"), () => {
 		hostRef.current?.moveCamera({ zoom: 1 });
@@ -432,7 +433,10 @@ export function MapEmbed({
 						/>
 					</div>
 				</div>
-				<div className="embed-controls__control" style={{ right: 0, bottom: 10 }}>
+				<div
+					className="embed-controls__control"
+					style={fullscreenMap ? { left: 0, bottom: 10 } : { right: 0, bottom: 10 }}
+				>
 					<div className="map-control map-control--button white">
 						<Tooltip content="Zoom in" side="left">
 							<button onClick={zoomIn} aria-label="Zoom in">

--- a/app/src/store/settings.ts
+++ b/app/src/store/settings.ts
@@ -98,6 +98,8 @@ const DEFAULTS = {
 	hidePanoUI: false,
 	fullscreenMap: false,
 	showFullscreenMapMeta: false,
+	showFullscreenMiniLocationPreview: true,
+	fullscreenMiniLocationScale: 1,
 	showFullscreenMinimap: true,
 	fullscreenMinimapScale: 1,
 	showFullscreenTagbar: true,

--- a/app/src/store/settings.ts
+++ b/app/src/store/settings.ts
@@ -97,6 +97,7 @@ const DEFAULTS = {
 	showGroundArrow: true,
 	hidePanoUI: false,
 	fullscreenMap: false,
+	showFullscreenMapMeta: false,
 	showFullscreenMinimap: true,
 	fullscreenMinimapScale: 1,
 	showFullscreenTagbar: true,

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -5285,14 +5285,26 @@ body {
 
 /* Fullscreen map mode: map takes full area, sidebar hidden */
 .page-map-editor.fullscreen-map {
-	grid-template: "map-embed map-embed" 1fr "map-meta map-meta" min-content/1fr;
+	height: 100vh;
+	margin: 0;
+	grid-gap: 0;
+	grid-template: "map-embed map-embed" 1fr/1fr;
 }
+.page-map-editor.fullscreen-map:has(> .map-meta) {
+	grid-template: "map-embed map-embed" 1fr "map-meta map-meta" min-content/1fr;
+	row-gap: 0.5rem;
+	padding: 0.5rem;
+}
+.page-map-editor.fullscreen-map > .split-handle,
 .page-map-editor.fullscreen-map > header,
 .page-map-editor.fullscreen-map > .side-header,
 .page-map-editor.fullscreen-map > .location-preview,
 .page-map-editor.fullscreen-map > .map-overview,
 .page-map-editor.fullscreen-map > .duplicates,
-.page-map-editor.fullscreen-map > .importer {
+.page-map-editor.fullscreen-map > .importer,
+.page-map-editor.fullscreen-map > .import-sidebar,
+.page-map-editor.fullscreen-map > .map-sidebar,
+.page-map-editor.fullscreen-map > .plugin-sidebar {
 	display: none;
 }
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -5385,6 +5385,69 @@ body {
 	opacity: 0.4;
 	cursor: default;
 }
+
+/* Fullscreen-map floating location preview (Street View chip) */
+.fullscreen-mini-location {
+	position: absolute;
+	bottom: 8px;
+	right: 8px;
+	width: 250px;
+	height: 140px;
+	border: 2px solid rgba(255, 255, 255, 0.4);
+	border-radius: 4px;
+	z-index: 12;
+	pointer-events: auto;
+	overflow: hidden;
+	opacity: 0.45;
+	transition:
+		width 0.2s,
+		height 0.2s,
+		opacity 0.2s;
+}
+.fullscreen-mini-location.is-expanded {
+	width: min(var(--fs-mini-loc-w, 480px), calc(100% - 16px));
+	height: min(var(--fs-mini-loc-h, 270px), calc(100% - 16px));
+	opacity: 1;
+}
+.fullscreen-mini-location__pano {
+	position: absolute;
+	inset: 0;
+}
+.fullscreen-mini-location__size {
+	position: absolute;
+	top: 6px;
+	left: 6px;
+	z-index: 1;
+	display: flex;
+	gap: 4px;
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+.fullscreen-mini-location.is-expanded .fullscreen-mini-location__size {
+	opacity: 1;
+}
+.fullscreen-mini-location__size-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background: rgba(30, 30, 30, 0.75);
+	color: #fff;
+	cursor: pointer;
+	transition: background 0.15s;
+}
+.fullscreen-mini-location__size-btn:hover {
+	background: rgba(30, 30, 30, 0.95);
+}
+.fullscreen-mini-location__size-btn:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
 /* Fullscreen bottom tray (date picker + tag bar) */
 .fullscreen-bottom-tray {
 	position: absolute;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -5386,7 +5386,9 @@ body {
 	cursor: default;
 }
 
-/* Fullscreen-map floating location preview (Street View chip) */
+/* Fullscreen-map floating location preview (Street View chip).
+ * Size snaps (no width/height transition) so the SV canvas isn't stretched
+ * mid-animation — that was causing hover-expand jitter. Opacity still fades. */
 .fullscreen-mini-location {
 	position: absolute;
 	bottom: 8px;
@@ -5399,10 +5401,7 @@ body {
 	pointer-events: auto;
 	overflow: hidden;
 	opacity: 0.45;
-	transition:
-		width 0.2s,
-		height 0.2s,
-		opacity 0.2s;
+	transition: opacity 0.2s;
 }
 .fullscreen-mini-location.is-expanded {
 	width: min(var(--fs-mini-loc-w, 480px), calc(100% - 16px));

--- a/app/test/e2e/fullscreen-map.test.ts
+++ b/app/test/e2e/fullscreen-map.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+	waitForReady,
+	createAndOpenMap,
+	closeMap,
+	deleteMap,
+	addLocs,
+	openLocation,
+	closeLocation,
+	withApi,
+	waitForActive,
+	waitForWorkArea,
+	createLocation,
+} from "./helpers";
+import type { Location } from "@/bindings.gen";
+
+function loc(overrides: Partial<Location> = {}): Location {
+	return createLocation({ lat: 40.758, lng: -73.9855, ...overrides });
+}
+
+async function waitForFullscreenMap(on: boolean) {
+	await browser.waitUntil(
+		async () => {
+			const active = await withApi((api) => api.getSettings().fullscreenMap);
+			if (active !== on) return false;
+			const el = await browser.$(".page-map-editor.fullscreen-map");
+			return on ? await el.isExisting() : !(await el.isExisting());
+		},
+		{ timeout: 5000, timeoutMsg: `fullscreenMap never became ${on}` },
+	);
+}
+
+async function waitForPanoFullscreen(on: boolean) {
+	await browser.waitUntil(
+		async () => {
+			const pano = await browser.$(".location-preview__panorama.is-fullscreen");
+			return on ? await pano.isExisting() : !(await pano.isExisting());
+		},
+		{ timeout: 5000, timeoutMsg: `pano fullscreen never became ${on}` },
+	);
+}
+
+describe("Fullscreen map mode", () => {
+	let mapId: string;
+	let locA: number;
+	let locB: number;
+
+	before(async () => {
+		await waitForReady();
+		mapId = await createAndOpenMap("E2E Fullscreen Map");
+		const ids = await addLocs([
+			loc({ lat: 40.758, lng: -73.9855 }),
+			loc({ lat: 40.761, lng: -73.978 }),
+		]);
+		locA = ids[0];
+		locB = ids[1];
+		await withApi(async (api) => {
+			api.setSetting("fullscreenMap", false);
+			api.setSetting("showFullscreenMiniLocationPreview", true);
+		});
+	});
+
+	after(async () => {
+		await closeLocation();
+		await withApi(async (api) => {
+			api.setSetting("fullscreenMap", false);
+		});
+		await closeMap();
+		await deleteMap(mapId);
+	});
+
+	afterEach(async () => {
+		await closeLocation();
+		await withApi(async (api) => api.setSetting("fullscreenMap", false));
+	});
+
+	it("enabling fullscreenMap adds the layout class", async () => {
+		await withApi(async (api) => api.setSetting("fullscreenMap", true));
+		await waitForFullscreenMap(true);
+	});
+
+	it("shows mini location preview when a location is open", async () => {
+		await withApi(async (api) => api.setSetting("fullscreenMap", true));
+		await waitForFullscreenMap(true);
+		await openLocation(locA);
+		await waitForWorkArea("location");
+		const mini = await browser.$(".fullscreen-mini-location");
+		await mini.waitForExist({ timeout: 5000 });
+	});
+
+	it("pano fullscreen (f) suspends fullscreen map and can be restored after delete", async () => {
+		await withApi(async (api) => api.setSetting("fullscreenMap", true));
+		await waitForFullscreenMap(true);
+		await openLocation(locA);
+		await waitForWorkArea("location");
+
+		await browser.$("body").click();
+		await browser.keys("f");
+		await waitForFullscreenMap(false);
+		await waitForPanoFullscreen(true);
+
+		await withApi(async (api) => api.removeLocations(new Set([locA])));
+		await waitForActive(null);
+		await waitForWorkArea("overview");
+		await waitForFullscreenMap(true);
+		await waitForPanoFullscreen(false);
+	});
+
+	it("switching locations while in pano fullscreen stays in pano fullscreen", async () => {
+		const [locC] = await addLocs([loc({ lat: 40.762, lng: -73.977 })]);
+		await openLocation(locB);
+		await waitForWorkArea("location");
+
+		await browser.$("body").click();
+		await browser.keys("f");
+		await waitForPanoFullscreen(true);
+
+		await openLocation(locC);
+		await waitForActive(locC);
+		await waitForWorkArea("location");
+		await waitForPanoFullscreen(true);
+	});
+
+	it("entering fullscreen map from pano fullscreen restores pano on exit", async () => {
+		await openLocation(locB);
+		await waitForWorkArea("location");
+
+		await browser.$("body").click();
+		await browser.keys("f");
+		await waitForPanoFullscreen(true);
+
+		await withApi(async (api) => api.setSetting("fullscreenMap", true));
+		await waitForFullscreenMap(true);
+		await waitForPanoFullscreen(false);
+
+		await withApi(async (api) => api.setSetting("fullscreenMap", false));
+		await waitForFullscreenMap(false);
+		await waitForPanoFullscreen(true);
+	});
+});

--- a/plugins/types/mma.d.ts
+++ b/plugins/types/mma.d.ts
@@ -2994,6 +2994,9 @@ declare const DEFAULTS: {
 	showGroundArrow: boolean;
 	hidePanoUI: boolean;
 	fullscreenMap: boolean;
+	showFullscreenMapMeta: boolean;
+	showFullscreenMiniLocationPreview: boolean;
+	fullscreenMiniLocationScale: number;
 	showFullscreenMinimap: boolean;
 	fullscreenMinimapScale: number;
 	showFullscreenTagbar: boolean;
@@ -3257,6 +3260,9 @@ declare const mma: {
 		showGroundArrow: boolean;
 		hidePanoUI: boolean;
 		fullscreenMap: boolean;
+		showFullscreenMapMeta: boolean;
+		showFullscreenMiniLocationPreview: boolean;
+		fullscreenMiniLocationScale: number;
 		showFullscreenMinimap: boolean;
 		fullscreenMinimapScale: number;
 		showFullscreenTagbar: boolean;


### PR DESCRIPTION
## Summary

Enhances fullscreen map mode with clearer chrome, a floating Street View mini preview, and mutually exclusive fullscreen toggles between map and panorama views.

## Changes

- **feat(ui): improve fullscreen map mode chrome and exit behavior** — Refines fullscreen map UI styling and exit flow in `MapEditor`, `MapEmbed`, and global styles.
- **feat(editor): add mini location preview for fullscreen map mode** — Adds `FullscreenMiniLocationPreview`, a resizable floating Street View chip that reuses the singleton pano while the main `LocationPreview` yields ownership. Includes a user setting for preview scale (`fullscreenMiniLocationScale`).
- **fix(editor): sync fullscreen map and pano fullscreen shortcuts** — Introduces `useFullscreenModeHotkeys` so `toggleFullscreen` and `toggleFullscreenMap` exit the other mode when entering one, preventing overlapping fullscreen states.

## Files touched

- `app/src/components/editor/location/FullscreenMiniLocationPreview.tsx` (new)
- `app/src/components/editor/location/useFullscreenModeHotkeys.ts` (new)
- `app/src/components/editor/MapEditor.tsx`
- `app/src/components/editor/location/LocationPreview.tsx`
- `app/src/components/editor/map/MapEmbed.tsx`
- `app/src/components/dialogs/SettingsPage.tsx`
- `app/src/store/settings.ts`
- `app/src/styles.css`

## Test plan

- [ ] Enter fullscreen map mode and verify updated chrome and exit behavior
- [ ] Confirm mini location preview appears, scales, and reuses the singleton pano correctly
- [ ] Toggle pano fullscreen while in map fullscreen (and vice versa) — only one mode should remain active
- [ ] Verify hotkeys `toggleFullscreen` and `toggleFullscreenMap` behave consistently with UI toggles