### PR TITLE
Apply typed tag without pressing enter

### DIFF
--- a/app/src/components/editor/ImportSidebar.tsx
+++ b/app/src/components/editor/ImportSidebar.tsx
@@ -87,7 +87,7 @@ export function ImportSidebar() {
 		setError(null);
 		const t = trace("import");
 		try {
-			const r = await confirmImport([...droppedFields], bulkTag ?? undefined);
+			const r = await confirmImport([...droppedFields], bulkTag ?? tagInput);
 			t.end({ imported: r?.importedCount ?? 0 });
 		} catch (e: unknown) {
 			log.error("[import] failed:", e);


### PR DESCRIPTION
Clicking Import now applies the current tag input directly, without requiring Enter first. Existing Enter/pill behavior and trim/empty handling remain unchanged.

Closes #105