### PR TITLE
Stack selection overlay markers by selection order

### DIFF
--- a/app/src-tauri/src/location_store.rs
+++ b/app/src-tauri/src/location_store.rs
@@ -377,8 +377,9 @@ pub(crate) struct EditEntry {
     pub removed: Vec<Location>,
 }
 
-/// Ids whose selection membership changed in a mutation. Carries no paint:
-/// `SelectionState::paint_for` is the one place a selection colour and draw order is decided.
+/// Ids whose selection paint changed in a mutation — including moves between overlapping
+/// selections, where union membership never flips but the winning colour does. Carries no
+/// paint: `SelectionState::paint_for` is the one place colour and draw order is decided.
 struct MembershipDelta {
     changed: HashSet<u32>,
 }
@@ -737,22 +738,22 @@ impl Store {
     }
 
     /// Update selection membership sets for incremental changes (adds/removes/updates).
-    /// Returns which ids crossed in or out of a selection, so the render delta can state
-    /// their new selection state.
+    /// Returns which ids changed paint, so the render delta can state their new
+    /// selection state.
     fn update_selection_membership(&mut self, changes: &ChangeSet) -> MembershipDelta {
-        let mut was_selected: HashSet<u32> = HashSet::new();
-
         let drop_ids: HashSet<u32> = changes
             .removed
             .iter()
             .copied()
             .chain(changes.updated.iter().map(|(_, n)| n.id))
             .collect();
+        // Paint before the mutation, snapshotted while the sets still reflect it. Paint is
+        // the compared fact — not union membership — because a row that moves between
+        // overlapping selections changes colour without ever leaving the union.
+        let mut prev_paint: HashMap<u32, Option<SelPaint>> = HashMap::new();
         if !drop_ids.is_empty() {
             for id in &drop_ids {
-                if self.selections.ids.contains(*id) {
-                    was_selected.insert(*id);
-                }
+                prev_paint.insert(*id, self.selections.paint_for(*id));
             }
             for r in &mut self.selections.resolved {
                 for id in &drop_ids {
@@ -794,7 +795,10 @@ impl Store {
             .iter()
             .chain(changes.updated.iter().map(|(_, n)| n))
         {
-            if self.selections.ids.contains(loc.id) != was_selected.contains(&loc.id) {
+            // Added rows have no snapshot: their previous paint is None, and they compare
+            // against whatever they resolve to now.
+            let before = prev_paint.get(&loc.id).copied().flatten();
+            if self.selections.paint_for(loc.id) != before {
                 changed.insert(loc.id);
             }
         }

--- a/app/src-tauri/src/location_store.rs
+++ b/app/src-tauri/src/location_store.rs
@@ -285,25 +285,34 @@ pub(crate) struct SelectionState {
 }
 
 impl SelectionState {
-    /// Color of a selected id = color of the last selection containing it. None if unselected.
-    fn color_for(&self, id: u32) -> Option<[u8; 3]> {
+    /// Paint of a selected id = the last selection containing it. None if unselected.
+    fn paint_for(&self, id: u32) -> Option<SelPaint> {
         if !self.ids.contains(id) {
             return None;
         }
-        let mut color = None;
-        for r in &self.resolved {
+        let mut paint = None;
+        for (i, r) in self.resolved.iter().enumerate() {
             if r.set.contains(id) {
-                color = Some(r.sel.color);
+                paint = Some(SelPaint {
+                    idx: i as u32,
+                    color: r.sel.color,
+                });
             }
         }
-        color
+        paint
     }
 
-    fn color_map(&self) -> HashMap<u32, [u8; 3]> {
+    /// Bulk form of `paint_for`. Later selections overwrite earlier ones, so each id ends
+    /// up with the same paint the per-id lookup would return.
+    fn paint_map(&self) -> HashMap<u32, SelPaint> {
         let mut map = HashMap::with_capacity(self.ids.len() as usize);
-        for r in &self.resolved {
+        for (i, r) in self.resolved.iter().enumerate() {
+            let paint = SelPaint {
+                idx: i as u32,
+                color: r.sel.color,
+            };
             for id in &r.set {
-                map.insert(id, r.sel.color);
+                map.insert(id, paint);
             }
         }
         map
@@ -368,8 +377,8 @@ pub(crate) struct EditEntry {
     pub removed: Vec<Location>,
 }
 
-/// Ids whose selection membership changed in a mutation. Carries no colour:
-/// `SelectionState::color_for` is the one place a selection colour is decided.
+/// Ids whose selection membership changed in a mutation. Carries no paint:
+/// `SelectionState::paint_for` is the one place a selection colour and draw order is decided.
 struct MembershipDelta {
     changed: HashSet<u32>,
 }
@@ -677,7 +686,7 @@ impl Store {
                 lng: loc.lng as f32,
                 lat: loc.lat as f32,
                 heading: self.render_angle(loc.heading),
-                sel: self.selections.color_for(loc.id),
+                sel: self.selections.paint_for(loc.id),
                 moved_from: None,
             });
         }
@@ -704,7 +713,7 @@ impl Store {
                     lng: new.lng as f32,
                     lat: new.lat as f32,
                     heading: self.render_angle(new.heading),
-                    sel: self.selections.color_for(new.id),
+                    sel: self.selections.paint_for(new.id),
                     moved_from,
                 });
                 continue;
@@ -718,7 +727,7 @@ impl Store {
                         lng: pos_changed.then_some(new.lng as f32),
                         lat: pos_changed.then_some(new.lat as f32),
                         heading: heading_changed.then(|| self.render_angle(new.heading)),
-                        sel: self.selections.color_for(new.id),
+                        sel: self.selections.paint_for(new.id),
                     });
                 }
             }
@@ -1839,6 +1848,17 @@ impl ChangeSet {
     }
 }
 
+/// The selection drawing a row: its colour, and its index in `SelectionState::resolved`.
+/// The index is the draw order — a later selection overdraws an earlier one — so the
+/// overlay can be ordered by it instead of by whatever order rows happen to arrive in.
+/// Every marker sits at z=0 in one deck.gl layer, so buffer order is the only z there is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SelPaint {
+    pub idx: u32,
+    pub color: [u8; 3],
+}
+
 /// A marker appended to a render cell: position, heading, and selection state.
 #[derive(serde::Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -1848,8 +1868,8 @@ pub struct RenderEntry {
     pub lng: f32,
     pub lat: f32,
     pub heading: f32,
-    /// `None` = drawn by the base layer, `Some(rgb)` = drawn by the selection overlay.
-    pub sel: Option<[u8; 3]>,
+    /// `None` = drawn by the base layer, `Some(paint)` = drawn by the selection overlay.
+    pub sel: Option<SelPaint>,
     /// The slot this row vacated when it crossed cells. Present only for a move, so JS
     /// mirrors the swap-remove and carries the overlay entry across instead of inferring
     /// a move from an unrelated removed/added pair.
@@ -1867,7 +1887,7 @@ pub struct RenderPatchEntry {
     pub lng: Option<f32>,
     pub lat: Option<f32>,
     pub heading: Option<f32>,
-    pub sel: Option<[u8; 3]>,
+    pub sel: Option<SelPaint>,
 }
 
 /// A swap-removal from a render cell. JS must move the last element into `cell_index`
@@ -3249,7 +3269,7 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
     let has_patches = !store.overlay.patches.is_empty();
 
     let selected_set: &RoaringBitmap = &store.selections.ids;
-    let color_map = store.selections.color_map();
+    let paint_map = store.selections.paint_map();
     let active_id = store.selections.active_id;
     let arrow_style = req.marker_style == "arrow";
 
@@ -3265,18 +3285,22 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
     const NONE: Option<CellOut> = None;
     let mut cells: [Option<CellOut>; 32] = [NONE; 32];
 
-    // Selection overlay: selected entries rendered as a separate colored layer
+    // Selection overlay: selected entries rendered as a separate colored layer. `sel_idx`
+    // is the drawing selection's index, both to order the entries below and so JS can keep
+    // them ordered as later edits add and drop entries.
     struct SelOverlay {
         ids: Vec<u32>,
         positions: Vec<f32>,
         colors: Vec<u8>,
         angles: Vec<f32>,
+        sel_idx: Vec<u32>,
     }
     let mut sel_ov = SelOverlay {
         ids: Vec::new(),
         positions: Vec::new(),
         colors: Vec::new(),
         angles: Vec::new(),
+        sel_idx: Vec::new(),
     };
 
     {
@@ -3296,12 +3320,17 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
             out.visible.push(if hidden { 0 } else { 255 });
             out.angles.push(angle);
             out.ids.push(id);
-            if let Some(&[r, g, b]) = color_map.get(&id) {
+            if let Some(&SelPaint {
+                idx,
+                color: [r, g, b],
+            }) = paint_map.get(&id)
+            {
                 sel_ov.positions.push(lng as f32);
                 sel_ov.positions.push(lat as f32);
                 sel_ov.colors.extend_from_slice(&[r, g, b, 255]);
                 sel_ov.angles.push(angle);
                 sel_ov.ids.push(id);
+                sel_ov.sel_idx.push(idx);
             }
         };
 
@@ -3324,6 +3353,42 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
         for loc in &store.overlay.adds {
             emit(loc.id, loc.lat, loc.lng, loc.heading);
         }
+    }
+
+    // Order the overlay by selection index, so a later selection's markers overdraw an
+    // earlier one's. Emitting in batch-row order instead would let two overlapping markers
+    // settle their z by whichever row came first in the batch. Counting sort — the key is a
+    // small dense integer, and it is stable, so rows within one selection keep batch order.
+    let num_sels = store.selections.resolved.len();
+    if num_sels > 1 && sel_ov.ids.len() > 1 {
+        let n = sel_ov.ids.len();
+        let mut at = vec![0u32; num_sels + 1];
+        for &si in &sel_ov.sel_idx {
+            at[si as usize + 1] += 1;
+        }
+        for i in 1..at.len() {
+            at[i] += at[i - 1];
+        }
+        let mut sorted = SelOverlay {
+            ids: vec![0; n],
+            positions: vec![0.0; n * 2],
+            colors: vec![0; n * 4],
+            angles: vec![0.0; n],
+            sel_idx: vec![0; n],
+        };
+        for src in 0..n {
+            let si = sel_ov.sel_idx[src] as usize;
+            let dst = at[si] as usize;
+            at[si] += 1;
+            sorted.positions[dst * 2] = sel_ov.positions[src * 2];
+            sorted.positions[dst * 2 + 1] = sel_ov.positions[src * 2 + 1];
+            sorted.colors[dst * 4..dst * 4 + 4]
+                .copy_from_slice(&sel_ov.colors[src * 4..src * 4 + 4]);
+            sorted.angles[dst] = sel_ov.angles[src];
+            sorted.ids[dst] = sel_ov.ids[src];
+            sorted.sel_idx[dst] = si as u32;
+        }
+        sel_ov = sorted;
     }
 
     // Rebuild per-cell render tracking
@@ -3367,6 +3432,7 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
             + sel_ov.colors.len()
             + sel_ov.angles.len() * 4
             + sel_ov.ids.len() * 4
+            + sel_ov.sel_idx.len() * 4
     };
     let mut buf = Vec::with_capacity(4 + body_cap + 4 + sel_cap);
     buf.extend_from_slice(&non_empty.to_le_bytes());
@@ -3387,7 +3453,8 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
         buf.extend_from_slice(bytemuck::cast_slice(&out.angles));
     }
 
-    // Selection overlay: [u32 count][f32[] positions][u8[] colors][f32[] angles][u32[] ids]
+    // Selection overlay, already ordered by selection index:
+    // [u32 count][f32[] positions][u8[] colors][f32[] angles][u32[] ids][u32[] selIdx]
     let sel_count = sel_ov.ids.len() as u32;
     buf.extend_from_slice(&sel_count.to_le_bytes());
     if sel_count > 0 {
@@ -3395,6 +3462,7 @@ fn build_cell_render_buffers(store: &mut Store, req: &RenderRequest) -> Vec<u8> 
         buf.extend_from_slice(&sel_ov.colors);
         buf.extend_from_slice(bytemuck::cast_slice(&sel_ov.angles));
         buf.extend_from_slice(bytemuck::cast_slice(&sel_ov.ids));
+        buf.extend_from_slice(bytemuck::cast_slice(&sel_ov.sel_idx));
     }
 
     log::debug!(

--- a/app/src-tauri/src/location_store.test.rs
+++ b/app/src-tauri/src/location_store.test.rs
@@ -2814,6 +2814,55 @@ fn removed_selected_location_leaves_no_patch() {
 }
 
 #[test]
+fn leaving_winning_selection_restates_survivors_paint() {
+    // A row in two overlapping selections is painted by the later one. Editing it out of
+    // the winner — without moving it — must ship a patch stating the survivor's paint:
+    // union membership never flips here, so this is exactly the case a union-flip test
+    // misses and the overlay would keep the dead winner's colour until a full resolve.
+    let both = loc_with_tags(1, 10.0, 20.0, vec![1, 2]);
+    let mut store = setup_store_with(&[both.clone()]);
+    insert_tag(&mut store, 1, 1);
+    insert_tag(&mut store, 2, 1);
+    add_tag_selection(&mut store, 1, [255, 0, 0]);
+    add_tag_selection(&mut store, 2, [0, 0, 255]);
+    store.resolve_selection_membership();
+    assert_eq!(
+        store.selections.paint_for(1),
+        Some(SelPaint {
+            idx: 1,
+            color: [0, 0, 255]
+        }),
+        "the later selection wins while the row is in both"
+    );
+
+    let only_first = loc_with_tags(1, 10.0, 20.0, vec![1]);
+    let result = store.finish_mutation(ChangeSet {
+        updated: vec![(both, only_first)],
+        ..Default::default()
+    });
+
+    assert_eq!(
+        result.delta.updated.len(),
+        1,
+        "leaving the winner while staying selected must still ship a patch"
+    );
+    let p = &result.delta.updated[0];
+    assert_eq!(
+        p.sel,
+        Some(SelPaint {
+            idx: 0,
+            color: [255, 0, 0]
+        }),
+        "the surviving selection's paint"
+    );
+    assert_eq!(
+        (p.lng, p.lat, p.heading),
+        (None, None, None),
+        "nothing moved, so only the selection state is stated"
+    );
+}
+
+#[test]
 fn membership_delta_no_patch_when_nothing_changed() {
     let l1 = loc_with_tags(1, 10.0, 20.0, vec![1]);
     let mut store = setup_store_with(&[l1.clone()]);

--- a/app/src-tauri/src/location_store.test.rs
+++ b/app/src-tauri/src/location_store.test.rs
@@ -2032,7 +2032,53 @@ fn render_buffer_with_selection_overlay() {
 }
 
 #[test]
-fn color_for_uses_last_matching_selection() {
+fn render_buffer_orders_the_overlay_by_selection() {
+    // Ids alternate between the two selections, so batch order and selection order
+    // disagree. The overlay draws in buffer order with every marker at z=0, so the
+    // second selection's markers have to come out last or they stack at random.
+    let locs: Vec<_> = (1..=4).map(|id| loc(id, 10.0, 20.0)).collect();
+    let mut store = setup_store_with(&locs);
+    store.bake_overlay();
+    push_resolved(&mut store, "a", [255, 0, 0], &[1, 3]);
+    push_resolved(&mut store, "b", [0, 0, 255], &[2, 4]);
+    for id in 1..=4 {
+        store.selections.ids.insert(id);
+    }
+
+    let req = RenderRequest {
+        west: -180.0,
+        south: -90.0,
+        east: 180.0,
+        north: 90.0,
+        selected_ids: None,
+        marker_style: "pin".into(),
+        marker_color: None,
+    };
+    let buf = build_cell_render_buffers(&mut store, &req);
+
+    let cell_count = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+    let mut offset = 4usize;
+    for _ in 0..cell_count {
+        let count = u32::from_le_bytes(buf[offset + 1..offset + 5].try_into().unwrap()) as usize;
+        offset += 8 + count * 4 + count * 2 * 4 + count + (4 - count % 4) % 4 + count * 4;
+    }
+    let n = u32::from_le_bytes(buf[offset..offset + 4].try_into().unwrap()) as usize;
+    assert_eq!(n, 4, "every location is selected");
+    offset += 4;
+    // positions, colors, angles, then ids and the selection indices.
+    let ids_at = offset + n * 8 + n * 4 + n * 4;
+    let sel_at = ids_at + n * 4;
+    let read = |at: usize, i: usize| {
+        u32::from_le_bytes(buf[at + i * 4..at + i * 4 + 4].try_into().unwrap())
+    };
+    let sel: Vec<u32> = (0..n).map(|i| read(sel_at, i)).collect();
+    let ids: Vec<u32> = (0..n).map(|i| read(ids_at, i)).collect();
+    assert_eq!(sel, vec![0, 0, 1, 1], "entries grouped by selection index");
+    assert_eq!(ids, vec![1, 3, 2, 4], "stable within a selection");
+}
+
+#[test]
+fn paint_for_uses_last_matching_selection() {
     let mut store = setup_store_with(&[loc(1, 0.0, 0.0)]);
     // id 1 belongs to two selections with different colors.
     for (key, color) in [("a", [255, 0, 0]), ("b", [0, 0, 255])] {
@@ -2040,16 +2086,15 @@ fn color_for_uses_last_matching_selection() {
     }
     store.selections.ids.insert(1);
 
-    assert_eq!(
-        store.selections.color_for(1),
-        Some([0, 0, 255]),
-        "last selection wins"
-    );
-    assert_eq!(store.selections.color_for(2), None, "unselected id");
+    let paint = store.selections.paint_for(1).expect("id 1 is selected");
+    assert_eq!(paint.color, [0, 0, 255], "last selection wins");
+    // The index is what the overlay orders by, so it must name the winning selection.
+    assert_eq!(paint.idx, 1, "index of the winning selection");
+    assert!(store.selections.paint_for(2).is_none(), "unselected id");
 }
 
 #[test]
-fn color_map_matches_color_for() {
+fn paint_map_matches_paint_for() {
     let mut store = setup_store_with(&[loc(1, 0.0, 0.0), loc(2, 0.0, 0.0), loc(3, 0.0, 0.0)]);
     for (key, color, members) in [
         ("a", [255, 0, 0], vec![1u32, 2]),
@@ -2061,14 +2106,11 @@ fn color_map_matches_color_for() {
         }
     }
 
-    let map = store.selections.color_map();
+    let map = store.selections.paint_map();
     for id in 1..=4 {
-        assert_eq!(
-            map.get(&id).copied(),
-            store.selections.color_for(id),
-            "id {}",
-            id
-        );
+        let bulk = map.get(&id).map(|p| (p.idx, p.color));
+        let single = store.selections.paint_for(id).map(|p| (p.idx, p.color));
+        assert_eq!(bulk, single, "id {}", id);
     }
 }
 
@@ -2629,7 +2671,13 @@ fn incremental_membership_change_ships_no_bitmask() {
         1,
         "membership rides on a patch for the row that changed"
     );
-    assert_eq!(result.delta.updated[0].sel, Some([255, 0, 0]));
+    assert_eq!(
+        result.delta.updated[0].sel,
+        Some(SelPaint {
+            idx: 0,
+            color: [255, 0, 0]
+        })
+    );
 }
 
 #[test]
@@ -2696,7 +2744,14 @@ fn membership_delta_reports_gained_on_tag_add() {
         .iter()
         .find(|p| p.sel.is_some())
         .expect("a row that joins a selection must state it");
-    assert_eq!(p.sel, Some([255, 0, 0]), "the selection colour");
+    assert_eq!(
+        p.sel,
+        Some(SelPaint {
+            idx: 0,
+            color: [255, 0, 0]
+        }),
+        "the selection colour"
+    );
     assert_eq!(
         (p.lng, p.lat, p.heading),
         (None, None, None),
@@ -2792,7 +2847,10 @@ fn membership_delta_no_patch_when_nothing_changed() {
     assert_eq!(result.delta.updated.len(), 1);
     assert_eq!(
         result.delta.updated[0].sel,
-        Some([255, 0, 0]),
+        Some(SelPaint {
+            idx: 0,
+            color: [255, 0, 0]
+        }),
         "a patch always states the row's current selection state"
     );
 }
@@ -2833,7 +2891,14 @@ fn selected_row_moving_across_cells_ships_as_one_move() {
         .iter()
         .find(|e| e.id == 1)
         .expect("re-added in the new cell");
-    assert_eq!(added.sel, Some([255, 0, 0]), "still selected");
+    assert_eq!(
+        added.sel,
+        Some(SelPaint {
+            idx: 0,
+            color: [255, 0, 0]
+        }),
+        "still selected"
+    );
     let from = added.moved_from.as_ref().expect("carries the vacated slot");
     assert_eq!(from.id, 1);
 }

--- a/app/src-tauri/src/selections.rs
+++ b/app/src-tauri/src/selections.rs
@@ -1124,6 +1124,103 @@ impl SpatialHash {
     }
 }
 
+/// Index groups keyed by exact coordinate, the degenerate-radius fallback shared by
+/// every duplicate path: "within 0 m" means exact-coordinate equality. The grid would
+/// divide by zero, saturate every point to one cell, and collapse to O(n^2). Hashing
+/// on exact coords instead is O(n); non-finite coordinates never match anything. (#69)
+fn exact_coord_groups(pts: &[(f64, f64)]) -> HashMap<(u64, u64), Vec<usize>> {
+    let mut groups: HashMap<(u64, u64), Vec<usize>> = HashMap::new();
+    for (i, &(lat, lng)) in pts.iter().enumerate() {
+        if !lat.is_finite() || !lng.is_finite() {
+            continue;
+        }
+        // `+ 0.0` folds -0.0 into +0.0 so the two compare equal.
+        groups
+            .entry(((lat + 0.0).to_bits(), (lng + 0.0).to_bits()))
+            .or_default()
+            .push(i);
+    }
+    groups
+}
+
+/// The grid broad-phase every duplicate path runs on: cell sizing, coordinate
+/// quantization, and the 3x3 neighborhood walk live here once, so the pair sweep and
+/// the parallel per-point scan cannot drift apart. Read-only after build, so callers
+/// may probe it from parallel iterators.
+struct DupGrid {
+    /// (lat, lng) per point, the coordinates the cells were quantized from.
+    pts: Vec<(f64, f64)>,
+    cells: Vec<(i32, i32)>,
+    grid: SpatialHash,
+    thresh_m2: f64,
+}
+
+impl DupGrid {
+    /// `None` for a degenerate radius (distance == 0, or a non-finite cell size) —
+    /// callers fall back to `exact_coord_groups`.
+    fn build(pts: &[(f64, f64)], distance_m: f64) -> Option<DupGrid> {
+        let cell_deg = distance_m / 111_000.0 * 1.5;
+        if !(cell_deg > 0.0) {
+            return None;
+        }
+        let pts = pts.to_vec();
+        let cells: Vec<(i32, i32)> = pts
+            .iter()
+            .map(|&(lat, lng)| {
+                (
+                    (lng / cell_deg).floor() as i32,
+                    (lat / cell_deg).floor() as i32,
+                )
+            })
+            .collect();
+        let grid = SpatialHash::build(&cells);
+        Some(DupGrid {
+            pts,
+            cells,
+            grid,
+            thresh_m2: distance_m * distance_m,
+        })
+    }
+
+    /// Visit every point within the distance threshold of `pi`, skipping indices below
+    /// `min_pj` before the distance test (`pi + 1` gives the ordered pair sweep, `0`
+    /// gives all neighbours). Stops early when `visit` returns true; returns whether it
+    /// stopped.
+    fn for_each_neighbor(
+        &self,
+        pi: usize,
+        min_pj: usize,
+        mut visit: impl FnMut(usize) -> bool,
+    ) -> bool {
+        let (lat, lng) = self.pts[pi];
+        let (cx, cy) = self.cells[pi];
+        let cos_lat = lat.to_radians().cos();
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                // saturating: a stray non-finite coord can floor to i32::MAX/MIN; a plain
+                // add would overflow (panic in debug, wrap in release).
+                let (nx, ny) = (cx.saturating_add(dx), cy.saturating_add(dy));
+                for &pj in self.grid.bucket(nx, ny) {
+                    let pj = pj as usize;
+                    if pj == pi || pj < min_pj {
+                        continue;
+                    }
+                    // Bucket may hold points from collided cells; the cell-coord check
+                    // keeps us to the true 3x3 neighborhood. Then the distance test.
+                    if self.cells[pj] != (nx, ny) {
+                        continue;
+                    }
+                    let (plat, plng) = self.pts[pj];
+                    if equirect_m2(lat, lng, plat, plng, cos_lat) <= self.thresh_m2 && visit(pj) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
 /// Grid broad-phase pair sweep shared by the duplicate groups/prune paths.
 /// Calls `pair(state, pi, pj)` (pi < pj) for every index pair within `distance_m`
 /// metres. O(N) average with uniform distribution, O(N^2) worst case if all points
@@ -1138,24 +1235,9 @@ fn for_pairs_within<S>(
     if n < 2 {
         return;
     }
-    let cell_deg = distance_m / 111_000.0 * 1.5;
-    // Degenerate radius (distance == 0, or a non-finite cell size): "within 0 m" means
-    // exact-coordinate equality. The grid would divide by zero, saturate every point to
-    // one cell, and collapse to O(n^2). Hash on exact coords instead — O(n). (#69)
-    if !(cell_deg > 0.0) {
-        let mut groups: HashMap<(u64, u64), Vec<usize>> = HashMap::new();
-        for i in 0..n {
-            let (lat, lng) = pos(i);
-            if !lat.is_finite() || !lng.is_finite() {
-                continue;
-            }
-            // `+ 0.0` folds -0.0 into +0.0 so the two compare equal.
-            groups
-                .entry(((lat + 0.0).to_bits(), (lng + 0.0).to_bits()))
-                .or_default()
-                .push(i);
-        }
-        for idxs in groups.values() {
+    let pts: Vec<(f64, f64)> = (0..n).map(pos).collect();
+    let Some(grid) = DupGrid::build(&pts, distance_m) else {
+        for idxs in exact_coord_groups(&pts).values() {
             for (a, &pi) in idxs.iter().enumerate() {
                 for &pj in &idxs[a + 1..] {
                     pair(state, pi, pj);
@@ -1163,44 +1245,12 @@ fn for_pairs_within<S>(
             }
         }
         return;
-    }
-    let cells: Vec<(i32, i32)> = (0..n)
-        .map(|i| {
-            let (lat, lng) = pos(i);
-            (
-                (lng / cell_deg).floor() as i32,
-                (lat / cell_deg).floor() as i32,
-            )
-        })
-        .collect();
-    let grid = SpatialHash::build(&cells);
-    let thresh_m2 = distance_m * distance_m;
+    };
     for pi in 0..n {
-        let (lat, lng) = pos(pi);
-        let (cx, cy) = cells[pi];
-        let cos_lat = lat.to_radians().cos();
-        for dx in -1..=1 {
-            for dy in -1..=1 {
-                // saturating: a stray non-finite coord can floor to i32::MAX/MIN; a plain
-                // add would overflow (panic in debug, wrap in release).
-                let (nx, ny) = (cx.saturating_add(dx), cy.saturating_add(dy));
-                for &pj in grid.bucket(nx, ny) {
-                    let pj = pj as usize;
-                    if pj <= pi {
-                        continue;
-                    }
-                    // Bucket may hold points from collided cells; the cell-coord check
-                    // keeps us to the true 3x3 neighborhood. Then the distance test.
-                    if cells[pj] != (nx, ny) {
-                        continue;
-                    }
-                    let (plat, plng) = pos(pj);
-                    if equirect_m2(lat, lng, plat, plng, cos_lat) <= thresh_m2 {
-                        pair(state, pi, pj);
-                    }
-                }
-            }
-        }
+        grid.for_each_neighbor(pi, pi + 1, |pj| {
+            pair(state, pi, pj);
+            false
+        });
     }
 }
 
@@ -1249,67 +1299,23 @@ fn find_duplicates_bitmask(view: &LocView, distance_m: f64, mask: &mut [bool]) {
         return;
     }
 
-    let cell_deg = distance_m / 111_000.0 * 1.5;
-    // Degenerate radius: "within 0 m" means exact-coordinate equality — count
-    // occupancy per exact coordinate; every member of a bucket of >= 2 is a dup. (#69)
-    if !(cell_deg > 0.0) {
-        let key = |p: &Pt| -> Option<(u64, u64)> {
-            if !p.lat.is_finite() || !p.lng.is_finite() {
-                return None;
-            }
-            // `+ 0.0` folds -0.0 into +0.0 so the two compare equal.
-            Some(((p.lat + 0.0).to_bits(), (p.lng + 0.0).to_bits()))
-        };
-        let mut counts: HashMap<(u64, u64), u32> = HashMap::new();
-        for p in &points {
-            if let Some(k) = key(p) {
-                *counts.entry(k).or_insert(0) += 1;
-            }
-        }
-        for p in &points {
-            if key(p).is_some_and(|k| counts[&k] >= 2) {
-                mask[p.global_idx] = true;
-            }
-        }
-        return;
-    }
-
-    let cells: Vec<(i32, i32)> = points
-        .iter()
-        .map(|p| {
-            (
-                (p.lng / cell_deg).floor() as i32,
-                (p.lat / cell_deg).floor() as i32,
-            )
-        })
-        .collect();
-    let grid = SpatialHash::build(&cells);
-    let thresh_m2 = distance_m * distance_m;
-
-    let has_neighbor = |pi: usize| -> bool {
-        let (lat, lng) = (points[pi].lat, points[pi].lng);
-        let (cx, cy) = cells[pi];
-        let cos_lat = lat.to_radians().cos();
-        for dx in -1..=1 {
-            for dy in -1..=1 {
-                let (nx, ny) = (cx.saturating_add(dx), cy.saturating_add(dy));
-                for &pj in grid.bucket(nx, ny) {
-                    let pj = pj as usize;
-                    if pj == pi || cells[pj] != (nx, ny) {
-                        continue;
-                    }
-                    if equirect_m2(lat, lng, points[pj].lat, points[pj].lng, cos_lat) <= thresh_m2 {
-                        return true;
-                    }
+    let pts: Vec<(f64, f64)> = points.iter().map(|p| (p.lat, p.lng)).collect();
+    // Degenerate radius: every member of an exact-coordinate group of >= 2 is a dup.
+    let Some(grid) = DupGrid::build(&pts, distance_m) else {
+        for idxs in exact_coord_groups(&pts).values() {
+            if idxs.len() >= 2 {
+                for &i in idxs {
+                    mask[points[i].global_idx] = true;
                 }
             }
         }
-        false
+        return;
     };
+
     let marks: Vec<bool> = (0..n)
         .into_par_iter()
         .with_min_len(4096)
-        .map(has_neighbor)
+        .map(|pi| grid.for_each_neighbor(pi, 0, |_| true))
         .collect();
     for (i, p) in points.iter().enumerate() {
         if marks[i] {

--- a/app/src/bindings.gen.ts
+++ b/app/src/bindings.gen.ts
@@ -979,8 +979,8 @@ export type RenderEntry = {
 	lng: number,
 	lat: number,
 	heading: number,
-	/**  `None` = drawn by the base layer, `Some(rgb)` = drawn by the selection overlay. */
-	sel: [number, number, number] | null,
+	/**  `None` = drawn by the base layer, `Some(paint)` = drawn by the selection overlay. */
+	sel: SelPaint | null,
 	/**
 	 *  The slot this row vacated when it crossed cells. Present only for a move, so JS
 	 *  mirrors the swap-remove and carries the overlay entry across instead of inferring
@@ -1000,7 +1000,7 @@ export type RenderPatchEntry = {
 	lng: number | null,
 	lat: number | null,
 	heading: number | null,
-	sel: [number, number, number] | null,
+	sel: SelPaint | null,
 };
 
 /**
@@ -1134,6 +1134,17 @@ export type SeenWriteEntry = {
 	countryCode: string | null,
 	address: string | null,
 	thumbnail: string | null,
+};
+
+/**
+ *  The selection drawing a row: its colour, and its index in `SelectionState::resolved`.
+ *  The index is the draw order — a later selection overdraws an earlier one — so the
+ *  overlay can be ordered by it instead of by whatever order rows happen to arrive in.
+ *  Every marker sits at z=0 in one deck.gl layer, so buffer order is the only z there is.
+ */
+export type SelPaint = {
+	idx: number,
+	color: [number, number, number],
 };
 
 /**

--- a/app/src/lib/render/CellManager.ts
+++ b/app/src/lib/render/CellManager.ts
@@ -1,7 +1,7 @@
-import type { RenderDelta, RenderEntry } from "@/bindings.gen";
+import type { RenderDelta, RenderEntry, SelPaint } from "@/bindings.gen";
 
-/** A marker's selection state: `null` = the base layer draws it, an RGB = the overlay does. */
-export type SelColor = [number, number, number] | null;
+/** A marker's selection state: `null` = the base layer draws it, a paint = the overlay does. */
+export type SelColor = SelPaint | null;
 
 function bitHas(bits: Uint8Array, id: number): boolean {
 	return (bits[id >>> 3] & (1 << (id & 7))) !== 0;
@@ -120,13 +120,20 @@ const MIN_CAPACITY = 256;
  * Presence is a bit array and id -> slot is a plain `Uint32Array`, so nothing here
  * hashes: a bulk rebuild costs one extra store per marker over writing the draw arrays
  * alone, and every by-id operation is O(1).
- * Writes swap-remove, so slots are unordered. Draw order does not matter.
+ *
+ * Writes swap-remove, so slots land unordered — but the overlay is one deck.gl layer and
+ * every marker sits at z=0, which makes slot order the only z-stacking there is. `order()`
+ * puts the slots back in selection order, and the batch entry points call it once they
+ * settle. Nothing else may hand these arrays to a layer.
  */
 export class SelectionOverlay {
 	positions = new Float32Array(0);
 	colors = new Uint8Array(0);
 	angles = new Float32Array(0);
 	ids = new Uint32Array(0);
+	/** Per-entry index of the selection drawing it, and the sort key `order()` uses.
+	 *  CPU-side bookkeeping like `ids` — never an attribute, never uploaded. */
+	sel = new Uint32Array(0);
 	count = 0;
 	version = 0;
 
@@ -134,14 +141,25 @@ export class SelectionOverlay {
 	private bits = new Uint8Array(0);
 	/** id -> slot. Only meaningful where `bits` is set, so it needs no empty sentinel. */
 	private slot = new Uint32Array(0);
+	/** Scratch for `order()`: entry -> destination slot. Reused across calls. */
+	private dest = new Uint32Array(0);
 
 	has(id: number): boolean {
 		const w = id >>> 3;
 		return w < this.bits.length && (this.bits[w] & (1 << (id & 7))) !== 0;
 	}
 
-	/** Add `id` to the overlay, or restate an existing entry. */
-	set(id: number, lng: number, lat: number, heading: number, color: [number, number, number]) {
+	/** Add `id` to the overlay, or restate an existing entry. `selIdx` is the drawing
+	 *  selection's index — the sort key `order()` needs, which no caller can recover from
+	 *  the colour alone once two selections share one. */
+	set(
+		id: number,
+		lng: number,
+		lat: number,
+		heading: number,
+		color: readonly [number, number, number],
+		selIdx: number,
+	) {
 		let i: number;
 		if (this.has(id)) {
 			i = this.slot[id];
@@ -155,6 +173,7 @@ export class SelectionOverlay {
 		this.positions[i * 2] = lng;
 		this.positions[i * 2 + 1] = lat;
 		this.angles[i] = heading;
+		this.sel[i] = selIdx;
 		const o = i * 4;
 		this.colors[o] = color[0];
 		this.colors[o + 1] = color[1];
@@ -181,6 +200,7 @@ export class SelectionOverlay {
 			this.positions.copyWithin(i * 2, last * 2, last * 2 + 2);
 			this.colors.copyWithin(i * 4, last * 4, last * 4 + 4);
 			this.angles[i] = this.angles[last];
+			this.sel[i] = this.sel[last];
 			const moved = this.ids[last];
 			this.ids[i] = moved;
 			this.slot[moved] = i;
@@ -195,24 +215,98 @@ export class SelectionOverlay {
 		this.version++;
 	}
 
+	/**
+	 * Sort the entries by selection index, so a later selection's markers overdraw an
+	 * earlier one's everywhere rather than wherever slot order happens to favour them.
+	 *
+	 * Counting sort: the key is a small dense integer, so it is two O(n) passes and an
+	 * array sized by the selection count. The leading scan makes the cases that need no
+	 * work — already ordered, or one selection in play — a single pass with no allocation,
+	 * which covers a plain single-selection map entirely.
+	 */
+	order() {
+		const n = this.count;
+		if (n < 2) return;
+		const sel = this.sel;
+		let lo = sel[0];
+		let hi = sel[0];
+		let sorted = true;
+		for (let i = 1; i < n; i++) {
+			const s = sel[i];
+			if (s < sel[i - 1]) sorted = false;
+			if (s < lo) lo = s;
+			if (s > hi) hi = s;
+		}
+		if (sorted || lo === hi) return;
+
+		// Bucket starts, then `dest[i]` = the slot entry `i` belongs in. Stable, so entries
+		// within one selection keep the order they were written in.
+		const at = new Uint32Array(hi - lo + 2);
+		for (let i = 0; i < n; i++) at[sel[i] - lo + 1]++;
+		for (let k = 1; k < at.length; k++) at[k] += at[k - 1];
+		if (this.dest.length < n) this.dest = new Uint32Array(n);
+		const dest = this.dest;
+		for (let i = 0; i < n; i++) dest[i] = at[sel[i] - lo]++;
+
+		// Apply the permutation in place by swapping each entry towards its slot. Every swap
+		// lands at least one entry for good, so this is O(n) with no second set of arrays.
+		for (let i = 0; i < n; i++) {
+			while (dest[i] !== i) {
+				const j = dest[i];
+				this.swap(i, j);
+				dest[i] = dest[j];
+				dest[j] = j;
+			}
+		}
+		this.version++;
+	}
+
+	/** Exchange two slots, keeping `slot` pointing at where each id actually lives. */
+	private swap(i: number, j: number) {
+		for (let k = 0; k < 2; k++) {
+			const t = this.positions[i * 2 + k];
+			this.positions[i * 2 + k] = this.positions[j * 2 + k];
+			this.positions[j * 2 + k] = t;
+		}
+		for (let k = 0; k < 4; k++) {
+			const t = this.colors[i * 4 + k];
+			this.colors[i * 4 + k] = this.colors[j * 4 + k];
+			this.colors[j * 4 + k] = t;
+		}
+		const a = this.angles[i];
+		this.angles[i] = this.angles[j];
+		this.angles[j] = a;
+		const s = this.sel[i];
+		this.sel[i] = this.sel[j];
+		this.sel[j] = s;
+		const id = this.ids[i];
+		this.ids[i] = this.ids[j];
+		this.ids[j] = id;
+		this.slot[this.ids[i]] = i;
+		this.slot[this.ids[j]] = j;
+	}
+
 	/** Snapshot of the selected ids. Copies the bit array so later edits can't mutate it. */
 	selectedIds(): SelectedIds {
 		if (this.count === 0) return SelectedIds.EMPTY;
 		return new SelectedIds(this.bits.slice(), this.count);
 	}
 
-	/** Replace every entry with arrays sliced straight out of Rust's render binary. */
+	/** Replace every entry with arrays sliced straight out of Rust's render binary, which
+	 *  ships them already in selection order. */
 	load(
 		positions: Float32Array<ArrayBuffer>,
 		colors: Uint8Array<ArrayBuffer>,
 		angles: Float32Array<ArrayBuffer>,
 		ids: Uint32Array<ArrayBuffer>,
+		sel: Uint32Array<ArrayBuffer>,
 		maxId: number,
 	) {
 		this.positions = positions;
 		this.colors = colors;
 		this.angles = angles;
 		this.ids = ids;
+		this.sel = sel;
 		this.count = this.capacity = ids.length;
 		this.bits = new Uint8Array((maxId >>> 3) + 1);
 		this.slot = new Uint32Array(maxId + 1);
@@ -237,6 +331,7 @@ export class SelectionOverlay {
 			this.colors = grow(this.colors, cap * 4, Uint8Array);
 			this.angles = grow(this.angles, cap, Float32Array);
 			this.ids = grow(this.ids, cap, Uint32Array);
+			this.sel = grow(this.sel, cap, Uint32Array);
 			this.capacity = cap;
 		}
 		// `bits` and `slot` are both indexed by id, so they grow together off one id capacity.
@@ -417,7 +512,8 @@ export class CellManager {
 			this.totalCount += count;
 		}
 
-		// Selection overlay: [u32 count][f32[] positions][u8[] colors][f32[] angles][u32[] ids]
+		// Selection overlay, in selection order:
+		// [u32 count][f32[] positions][u8[] colors][f32[] angles][u32[] ids][u32[] selIdx]
 		if (offset + 4 <= buf.byteLength) {
 			const selCount = dv.getUint32(offset, true);
 			offset += 4;
@@ -429,7 +525,9 @@ export class CellManager {
 				const ang = new Float32Array(buf, offset, selCount);
 				offset += selCount * 4;
 				const ids = new Uint32Array(buf, offset, selCount);
-				this.overlay.load(pos, col, ang, ids, this.maxId);
+				offset += selCount * 4;
+				const sel = new Uint32Array(buf, offset, selCount);
+				this.overlay.load(pos, col, ang, ids, sel, this.maxId);
 			}
 		}
 
@@ -447,6 +545,7 @@ export class CellManager {
 	 */
 	applyDelta(delta: RenderDelta): Set<string> {
 		const affected = new Set<string>();
+		const overlayBefore = this.overlay.version;
 
 		for (const rem of delta.removed) {
 			const cb = this.cells.get(rem.cell);
@@ -495,6 +594,13 @@ export class CellManager {
 			this.setSelection(cb, i, patch.sel);
 		}
 
+		// Entries just added landed at the end of the overlay and deletes swapped the tail
+		// into the hole, so the slots have to be put back in selection order before they
+		// are drawn — otherwise an edited marker jumps in front of everything. Guarded on
+		// the overlay having moved at all, so a delta that touches no selected row doesn't
+		// pay a scan over every selected marker on the map.
+		if (this.overlay.version !== overlayBefore) this.overlay.order();
+
 		this.version++;
 		return affected;
 	}
@@ -505,8 +611,12 @@ export class CellManager {
 	 *  active-location path, which only knows an id. */
 	private setSelection(cb: CellBuffer, i: number, sel: SelColor) {
 		const id = cb.ids[i];
-		if (sel) this.overlay.set(id, cb.positions[i * 2], cb.positions[i * 2 + 1], cb.angles[i], sel);
-		else this.overlay.delete(id);
+		if (sel) {
+			const p = cb.positions;
+			this.overlay.set(id, p[i * 2], p[i * 2 + 1], cb.angles[i], sel.color, sel.idx);
+		} else {
+			this.overlay.delete(id);
+		}
 		cb.patchVisible(i, sel || id === this.activeId ? 0 : 255);
 	}
 
@@ -625,10 +735,16 @@ export class CellManager {
 					cb.positions[li * 2 + 1],
 					cb.angles[li],
 					selColors[si],
+					si,
 				);
 				cb.visible[li] = 0;
 			}
 		}
+
+		// Written cell by cell, so the slots come out in row order. Sorting them by selection
+		// is what makes the winner above hold between neighbouring markers too, not just
+		// between two selections covering the same row.
+		this.overlay.order();
 
 		// The active row was shown again along with the rest of its cell.
 		if (this.activeId != null) this.syncVisible(this.activeId);

--- a/app/test/unit/cellManager.test.ts
+++ b/app/test/unit/cellManager.test.ts
@@ -19,6 +19,12 @@ function entry(
 	return { cell, id, lng, lat, heading, sel, movedFrom: null };
 }
 
+/** A `SelColor`: the paint a delta entry carries. `idx` is the drawing selection's
+ *  position in the selection list, which is what the overlay orders by. */
+function paint(color: [number, number, number], idx = 0): SelColor {
+	return { idx, color };
+}
+
 /** A render delta with everything defaulted, so a case names only what it exercises. */
 function delta(parts: Partial<RenderDelta> = {}): RenderDelta {
 	return { added: [], updated: [], removed: [], fullReset: false, ...parts };
@@ -182,7 +188,7 @@ describe("CellManager", () => {
 		mgr.applyDelta(delta({ added: [entry("s", 1, 10, 20)] }));
 		mgr.applyDelta(
 			delta({
-				updated: [selPatch("s", 0, [255, 0, 0])],
+				updated: [selPatch("s", 0, paint([255, 0, 0]))],
 			}),
 		);
 		expect(mgr.cells.get("s")!.visible[0]).toBe(0);
@@ -192,7 +198,7 @@ describe("CellManager", () => {
 	});
 
 	it("a patch stating no selection returns the row to the base layer", () => {
-		mgr.applyDelta(delta({ added: [entry("s", 1, 10, 20, 0, [255, 0, 0])] }));
+		mgr.applyDelta(delta({ added: [entry("s", 1, 10, 20, 0, paint([255, 0, 0]))] }));
 		expect(mgr.overlay.count).toBe(1);
 		mgr.applyDelta(
 			delta({
@@ -338,7 +344,7 @@ describe("CellManager", () => {
 
 	it("initFromBinary parses selection overlay", () => {
 		// 0 cells + 1 selection overlay entry
-		const buf = new ArrayBuffer(4 + 4 + 2 * 4 + 4 + 4 + 4);
+		const buf = new ArrayBuffer(4 + 4 + 2 * 4 + 4 + 4 + 4 + 4);
 		const dv = new DataView(buf);
 		let off = 0;
 		dv.setUint32(off, 0, true);
@@ -364,12 +370,16 @@ describe("CellManager", () => {
 		off += 4;
 		// id
 		dv.setUint32(off, 7, true);
+		off += 4;
+		// selection index
+		dv.setUint32(off, 3, true);
 
 		mgr.initFromBinary(buf);
 		expect(mgr.overlay.count).toBe(1);
 		expect(mgr.overlay.ids[0]).toBe(7);
 		expect(mgr.overlay.positions[0]).toBeCloseTo(5.5);
 		expect(mgr.overlay.colors[0]).toBe(255);
+		expect(mgr.overlay.sel[0]).toBe(3);
 		// The loaded overlay is indexed, not just drawn: membership answers come off it.
 		expect(mgr.overlay.has(7)).toBe(true);
 		expect(mgr.selectedIds().has(7)).toBe(true);
@@ -391,7 +401,7 @@ describe("CellManager", () => {
 	it("an added entry that is already selected goes straight into the overlay", () => {
 		mgr.applyDelta(
 			delta({
-				added: [entry("s", 1, 10, 20, 45, [255, 0, 0]), entry("s", 2, 30, 40, 90)],
+				added: [entry("s", 1, 10, 20, 45, paint([255, 0, 0])), entry("s", 2, 30, 40, 90)],
 			}),
 		);
 		expect(mgr.overlay.count).toBe(1);
@@ -404,7 +414,7 @@ describe("CellManager", () => {
 	});
 
 	it("movedFrom carries a selected row's overlay entry across cells", () => {
-		mgr.applyDelta(delta({ added: [entry("s", 1, 10, 20, 0, [0, 255, 0])] }));
+		mgr.applyDelta(delta({ added: [entry("s", 1, 10, 20, 0, paint([0, 255, 0]))] }));
 		expect(mgr.overlay.count).toBe(1);
 
 		mgr.applyDelta(
@@ -416,7 +426,7 @@ describe("CellManager", () => {
 						lng: 99,
 						lat: 88,
 						heading: 0,
-						sel: [0, 255, 0],
+						sel: paint([0, 255, 0]),
 						movedFrom: { cell: "s", cellIndex: 0, id: 1 },
 					},
 				],
@@ -437,7 +447,7 @@ describe("CellManager", () => {
 	it("setActive hides the active row and restores it, without disturbing selection", () => {
 		mgr.applyDelta(
 			delta({
-				added: [entry("s", 1, 10, 20), entry("s", 2, 30, 40, 0, [255, 0, 0])],
+				added: [entry("s", 1, 10, 20), entry("s", 2, 30, 40, 0, paint([255, 0, 0]))],
 			}),
 		);
 		const cb = mgr.cells.get("s")!;
@@ -645,6 +655,75 @@ describe("applySelectionBitmasks", () => {
 		expect(mgr.overlay.colors[idx10 * 4]).toBe(255);
 		const idx30 = mgr.overlay.ids.indexOf(30);
 		expect(mgr.overlay.colors[idx30 * 4 + 2]).toBe(255);
+	});
+
+	it("orders the overlay by selection, whatever order the rows sit in", () => {
+		// Rows alternate between the two selections, so row order and selection order
+		// disagree for every marker but the first.
+		mgr.applyDelta(
+			delta({
+				added: [
+					entry("s", 10, 1, 1),
+					entry("s", 20, 2, 2),
+					entry("s", 30, 3, 3),
+					entry("s", 40, 4, 4),
+				],
+			}),
+		);
+
+		// Selection 0 (red): rows 0, 2. Selection 1 (blue): rows 1, 3.
+		mgr.applySelectionBitmasks(
+			[
+				[255, 0, 0],
+				[0, 0, 255],
+			],
+			[
+				{
+					cellChar: "s",
+					locCount: 4,
+					sels: [maskSel(new Uint8Array([0b0101])), maskSel(new Uint8Array([0b1010]))],
+				},
+			],
+		);
+
+		// Buffer order is the only z-stacking these markers have, so every blue entry has
+		// to sit after every red one — not just the ones that happen to come later by row.
+		const sel = [...mgr.overlay.sel.slice(0, mgr.overlay.count)];
+		expect(sel).toEqual([0, 0, 1, 1]);
+		const ids = [...mgr.overlay.ids.slice(0, mgr.overlay.count)];
+		expect(new Set(ids.slice(0, 2))).toEqual(new Set([10, 30]));
+		expect(new Set(ids.slice(2))).toEqual(new Set([20, 40]));
+		// Colours travelled with their rows through the reorder.
+		for (let i = 0; i < mgr.overlay.count; i++) {
+			const red = mgr.overlay.colors[i * 4] === 255;
+			expect(red).toBe(mgr.overlay.sel[i] === 0);
+		}
+	});
+
+	it("keeps the overlay ordered when a delta repaints a row", () => {
+		mgr.applyDelta(
+			delta({
+				added: [
+					entry("s", 10, 1, 1, 0, paint([0, 0, 255], 1)),
+					entry("s", 20, 2, 2, 0, paint([0, 0, 255], 1)),
+					entry("s", 30, 3, 3),
+				],
+			}),
+		);
+		expect([...mgr.overlay.sel.slice(0, 2)]).toEqual([1, 1]);
+
+		// Row 30 joins the *earlier* selection. Appended at the end, it would draw over
+		// both blue markers; it belongs underneath them.
+		mgr.applyDelta(delta({ updated: [selPatch("s", 2, paint([255, 0, 0], 0))] }));
+
+		expect(mgr.overlay.count).toBe(3);
+		expect([...mgr.overlay.sel.slice(0, 3)]).toEqual([0, 1, 1]);
+		expect(mgr.overlay.ids[0]).toBe(30);
+		expect(mgr.overlay.colors[0]).toBe(255);
+		// The id index survived the reorder, so membership answers still work.
+		expect(mgr.overlay.has(30)).toBe(true);
+		expect(mgr.overlay.has(10)).toBe(true);
+		expect(mgr.overlay.has(20)).toBe(true);
 	});
 
 	it("selected entries get alpha=0 in main layer (hidden)", () => {

--- a/app/test/unit/renderAssurance.test.ts
+++ b/app/test/unit/renderAssurance.test.ts
@@ -19,6 +19,12 @@ function entry(
 	return { cell, id, lng, lat, heading, sel, movedFrom: null };
 }
 
+/** A `SelColor`: the paint a delta entry carries. `idx` is the drawing selection's
+ *  position in the selection list, which is what the overlay orders by. */
+function paint(color: [number, number, number], idx = 0): SelColor {
+	return { idx, color };
+}
+
 /** A render delta with everything defaulted, so a case names only what it exercises. */
 function delta(parts: Partial<RenderDelta> = {}): RenderDelta {
 	return { added: [], updated: [], removed: [], fullReset: false, ...parts };
@@ -486,7 +492,7 @@ describe("Deltas during active selections", () => {
 		mgr.applyDelta(
 			delta({
 				updated: [
-					{ cell: "s", cellIndex: idx, lng: 999, lat: 888, heading: null, sel: [255, 0, 0] },
+					{ cell: "s", cellIndex: idx, lng: 999, lat: 888, heading: null, sel: paint([255, 0, 0]) },
 				],
 			}),
 		);
@@ -507,7 +513,9 @@ describe("Deltas during active selections", () => {
 
 		mgr.applyDelta(
 			delta({
-				updated: [{ cell: "s", cellIndex: idx, lng: 999, lat: 888, heading: 45, sel: [255, 0, 0] }],
+				updated: [
+					{ cell: "s", cellIndex: idx, lng: 999, lat: 888, heading: 45, sel: paint([255, 0, 0]) },
+				],
 			}),
 		);
 
@@ -535,7 +543,7 @@ describe("Deltas during active selections", () => {
 						lng: 7,
 						lat: 8,
 						heading: 0,
-						sel: [255, 0, 0],
+						sel: paint([255, 0, 0]),
 						movedFrom: { cell: "s", cellIndex: idx, id: 2 },
 					},
 				],
@@ -557,7 +565,7 @@ describe("Deltas during active selections", () => {
 		selectIds(mgr, new Set([1]));
 		const before = mgr.overlay.count;
 
-		mgr.applyDelta(delta({ updated: [selPatch("s", 9999, [1, 2, 3])] }));
+		mgr.applyDelta(delta({ updated: [selPatch("s", 9999, paint([1, 2, 3]))] }));
 
 		expect(mgr.overlay.count).toBe(before);
 		expect(mgr.selectedIds().has(0)).toBe(false);
@@ -593,7 +601,7 @@ describe("Deltas during active selections", () => {
 		const cellIndex = cb.idToIndex.get(2)!;
 
 		// Same id patched selected twice: the overlay must still hold exactly one entry.
-		const patch = selPatch("s", cellIndex, [0, 200, 0]);
+		const patch = selPatch("s", cellIndex, paint([0, 200, 0]));
 		mgr.applyDelta(delta({ updated: [patch] }));
 		mgr.applyDelta(delta({ updated: [patch] }));
 
@@ -623,7 +631,7 @@ describe("Membership propagation via selection patches", () => {
 	it("a patch hides only the rows it names", () => {
 		mgr.applyDelta(
 			delta({
-				updated: [selPatch("s", 0, [50, 200, 50]), selPatch("s", 1, [50, 200, 50])],
+				updated: [selPatch("s", 0, paint([50, 200, 50])), selPatch("s", 1, paint([50, 200, 50]))],
 			}),
 		);
 
@@ -641,7 +649,7 @@ describe("Membership propagation via selection patches", () => {
 			}),
 		);
 
-		mgr.applyDelta(delta({ updated: [selPatch("s", 0, [0, 255, 0])] }));
+		mgr.applyDelta(delta({ updated: [selPatch("s", 0, paint([0, 255, 0]))] }));
 
 		expect(cb.ids[0]).toBe(3);
 		expect(getVisible(mgr, 3)).toBe(0);
@@ -957,15 +965,15 @@ describe("SelectionOverlay id index", () => {
 
 	it("set is idempotent and restates colour in place", () => {
 		const ov = mgr.overlay;
-		ov.set(1, 10, 20, 0, [255, 0, 0]);
-		ov.set(1, 10, 20, 0, [0, 0, 255]);
+		ov.set(1, 10, 20, 0, [255, 0, 0], 0);
+		ov.set(1, 10, 20, 0, [0, 0, 255], 0);
 		expect(ov.count).toBe(1);
 		expect([...ov.colors.slice(0, 4)]).toEqual([0, 0, 255, 255]);
 	});
 
 	it("delete swap-removes and keeps every surviving id findable", () => {
 		const ov = mgr.overlay;
-		for (const id of [1, 2, 3, 4, 5]) ov.set(id, id, id, 0, [255, 0, 0]);
+		for (const id of [1, 2, 3, 4, 5]) ov.set(id, id, id, 0, [255, 0, 0], 0);
 
 		ov.delete(1); // id 5 swaps into slot 0
 		ov.delete(3);
@@ -981,7 +989,7 @@ describe("SelectionOverlay id index", () => {
 
 	it("deleting an absent id is a no-op", () => {
 		const ov = mgr.overlay;
-		ov.set(1, 1, 1, 0, [255, 0, 0]);
+		ov.set(1, 1, 1, 0, [255, 0, 0], 0);
 		const v = ov.version;
 		ov.delete(99);
 		expect(ov.count).toBe(1);
@@ -990,8 +998,8 @@ describe("SelectionOverlay id index", () => {
 
 	it("selectedIds snapshots, so a later delete does not rewrite it", () => {
 		const ov = mgr.overlay;
-		ov.set(1, 1, 1, 0, [255, 0, 0]);
-		ov.set(2, 2, 2, 0, [255, 0, 0]);
+		ov.set(1, 1, 1, 0, [255, 0, 0], 0);
+		ov.set(2, 2, 2, 0, [255, 0, 0], 0);
 		const snapshot = ov.selectedIds();
 		ov.delete(1);
 		expect(snapshot.has(1)).toBe(true);
@@ -1000,7 +1008,7 @@ describe("SelectionOverlay id index", () => {
 
 	it("clear empties membership without leaving stale bits", () => {
 		const ov = mgr.overlay;
-		for (const id of [1, 2, 3]) ov.set(id, id, id, 0, [255, 0, 0]);
+		for (const id of [1, 2, 3]) ov.set(id, id, id, 0, [255, 0, 0], 0);
 		ov.clear();
 		expect(ov.count).toBe(0);
 		for (const id of [1, 2, 3]) expect(ov.has(id)).toBe(false);

--- a/plugins/types/mma.d.ts
+++ b/plugins/types/mma.d.ts
@@ -1024,8 +1024,8 @@ type RenderEntry = {
     lng: number;
     lat: number;
     heading: number;
-    /**  `None` = drawn by the base layer, `Some(rgb)` = drawn by the selection overlay. */
-    sel: [number, number, number] | null;
+    /**  `None` = drawn by the base layer, `Some(paint)` = drawn by the selection overlay. */
+    sel: SelPaint | null;
     /**
      *  The slot this row vacated when it crossed cells. Present only for a move, so JS
      *  mirrors the swap-remove and carries the overlay entry across instead of inferring
@@ -1044,7 +1044,7 @@ type RenderPatchEntry = {
     lng: number | null;
     lat: number | null;
     heading: number | null;
-    sel: [number, number, number] | null;
+    sel: SelPaint | null;
 };
 /**
  *  Parameters for a full render rebuild. `marker_style` ("arrow" or "pin") determines
@@ -1170,6 +1170,16 @@ type SeenWriteEntry = {
     countryCode: string | null;
     address: string | null;
     thumbnail: string | null;
+};
+/**
+ *  The selection drawing a row: its colour, and its index in `SelectionState::resolved`.
+ *  The index is the draw order — a later selection overdraws an earlier one — so the
+ *  overlay can be ordered by it instead of by whatever order rows happen to arrive in.
+ *  Every marker sits at z=0 in one deck.gl layer, so buffer order is the only z there is.
+ */
+type SelPaint = {
+    idx: number;
+    color: [number, number, number];
 };
 /**
  *  A named, colored selection. `key` is deterministic (e.g., `"tag:5"`, `"polygon:abc"`)
@@ -1816,6 +1826,7 @@ declare namespace store {
 declare function loadGeoJSON(): Promise<void>;
 
 declare const requiresMap: () => boolean;
+declare const hasActiveLocation: () => boolean;
 declare const hasSelection: () => boolean;
 declare const hasAnySelections: () => boolean;
 /** Every editor command (palette entries; all are hotkey-bindable in Settings). */
@@ -1848,7 +1859,7 @@ declare const COMMANDS: {
         icon: string;
         group: "Map";
         execute: () => void;
-        enabled: typeof requiresMap;
+        enabled: typeof hasActiveLocation;
     };
     undo: {
         label: string;
@@ -2777,6 +2788,7 @@ declare const EVENT_DEFS: {
     "store:changed": void;
     "render:delta": RenderDelta;
     "render:selection": SelectionBitmaskPayload;
+    "map-list:changed": void;
     "settings:changed": void;
     "fullscreen:changed": void;
     "plugins:changed": void;
@@ -3221,4 +3233,4 @@ declare global {
 }
 
 export { MMA as MMAApi, PanoType, commands };
-export type { CellRemoval, CommitDelta, CommitDiff, CommitInfo, ComparisonType, Conflict, ConflictKind, CopyToMapResult, DataLocation, DatePart, DbStats, DbTableInfo, EditorImportPreview, EditorImportResult, ExportOpts, ExtraFieldDef, ExtraFieldType, FieldCount, FilterOp, FirstSyncMode, GeoResult, GgUser, ImportPreviewEntry, ImportedMapInfo, KeySpec, Location, LocationPatch, LocationPatch_Deserialize, MapData, MapExtra, MapKeyAction, MapKeyBinding, MapMeta, MapMetaPatch, MapMetaPatch_Deserialize, MapSettings, MutationResult, NormalizedSyncLocation, NumericBinning, PartitionBucket, PluginManifest, PluginManifest_Deserialize, PluginSidecar, PluginSidecar_Deserialize, PolygonGeometry, PresenceActivity, PullCreate, PullUpdate, RemoteMappingRow, RenderDelta, RenderEntry, RenderPatchEntry, RenderRequest, ResolutionSide, ReviewCreate, ReviewSession, ReviewUpdate, SaveResult, Scope, ScoreBounds, SeenEntry, SeenFilter, SeenMapInfo, SeenWriteEntry, Selection, SelectionInput, SelectionProps, SelectionSync, SideCounts, SpacedPickResult, StoreStatus, SummaryResult, SyncPatch, SyncReconcileResult, Tag, TagPatch, Update, ValiLocation, ValiLocation_Deserialize, VirtualTag };
+export type { CellRemoval, CommitDelta, CommitDiff, CommitInfo, ComparisonType, Conflict, ConflictKind, CopyToMapResult, DataLocation, DatePart, DbStats, DbTableInfo, EditorImportPreview, EditorImportResult, ExportOpts, ExtraFieldDef, ExtraFieldType, FieldCount, FilterOp, FirstSyncMode, GeoResult, GgUser, ImportPreviewEntry, ImportedMapInfo, KeySpec, Location, LocationPatch, LocationPatch_Deserialize, MapData, MapExtra, MapKeyAction, MapKeyBinding, MapMeta, MapMetaPatch, MapMetaPatch_Deserialize, MapSettings, MutationResult, NormalizedSyncLocation, NumericBinning, PartitionBucket, PluginManifest, PluginManifest_Deserialize, PluginSidecar, PluginSidecar_Deserialize, PolygonGeometry, PresenceActivity, PullCreate, PullUpdate, RemoteMappingRow, RenderDelta, RenderEntry, RenderPatchEntry, RenderRequest, ResolutionSide, ReviewCreate, ReviewSession, ReviewUpdate, SaveResult, Scope, ScoreBounds, SeenEntry, SeenFilter, SeenMapInfo, SeenWriteEntry, SelPaint, Selection, SelectionInput, SelectionProps, SelectionSync, SideCounts, SpacedPickResult, StoreStatus, SummaryResult, SyncPatch, SyncReconcileResult, Tag, TagPatch, Update, ValiLocation, ValiLocation_Deserialize, VirtualTag };


### PR DESCRIPTION
Selected markers all draw in one deck.gl layer at z=0, so buffer order is the only z-stacking there is. Since 9daf831 the overlay was written in cell/row order instead of selection order, so two overlapping selections stacked at random per marker — some blue markers above yellow, some below.

Fix: each overlay entry carries the winning selection's index (`SelPaint`), and the overlay is kept grouped by it with a stable counting sort at every mutation point (Rust blob build, bitmask rebuild, delta application). The index stays CPU-side — never a GPU attribute — so the one-entry-per-location efficiency from 9daf831 is preserved.

Also fixes a delta-path gap found along the way: a row dropping out of its winning selection while staying in an overlapping one never shipped a patch, so it kept the dead winner's colour until the next full resolve.
