### PR TITLE
fix: show the saved export filename

### DIFF
--- a/app/src/components/dialogs/ExportDialog.tsx
+++ b/app/src/components/dialogs/ExportDialog.tsx
@@ -17,221 +17,235 @@ import { t } from "@/lib/i18n";
 import { Trans } from "@/components/primitives/Trans";
 
 interface Props {
-	onClose: () => void;
+  onClose: () => void;
 }
 
 export function ExportDialog({ onClose }: Props) {
-	const map = useMapState((s) => s.map);
-	const selectedIds = useMapState((s) => s.selectedLocationIds);
-	const locationCount = useMapState((s) => s.locationCount);
-	const uid = useId();
+  const map = useMapState((s) => s.map);
+  const selectedIds = useMapState((s) => s.selectedLocationIds);
+  const locationCount = useMapState((s) => s.locationCount);
+  const uid = useId();
 
-	const [pick, setPick] = useState<SelectorPick>({ pick: "all" });
-	// Derived, not stored: "the selection" has to follow the live one.
-	const selector = selectorForPick(pick);
-	const [saveZoom, setSaveZoom] = useMapSetting("exportZoom");
-	const [saveExtras, setSaveExtras] = useMapSetting("exportExtras");
-	const [bypassUnpanned, setBypassUnpanned] = useMapSetting("exportUnpanned");
-	const [fileName, setFileName] = useState(map?.name ?? "");
-	const selCount = selectedIds.size;
+  const [pick, setPick] = useState<SelectorPick>({ pick: "all" });
+  // Derived, not stored: "the selection" has to follow the live one.
+  const selector = selectorForPick(pick);
+  const [saveZoom, setSaveZoom] = useMapSetting("exportZoom");
+  const [saveExtras, setSaveExtras] = useMapSetting("exportExtras");
+  const [bypassUnpanned, setBypassUnpanned] = useMapSetting("exportUnpanned");
+  const [fileName, setFileName] = useState(map?.name ?? "");
+  const selCount = selectedIds.size;
 
-	if (!map) return null;
+  if (!map) return null;
 
-	const baseName = fileName || map.name || "export";
+  const baseName = fileName || map.name || "export";
 
-	const tagsJson = () => JSON.stringify(Object.fromEntries(getVisibleTags().map((t) => [t.id, t])));
+  const tagsJson = () =>
+    JSON.stringify(Object.fromEntries(getVisibleTags().map((t) => [t.id, t])));
 
-	const jsonPath = () =>
-		cmd.storeExportJson({
-			exportZoom: saveZoom,
-			exportUnpanned: bypassUnpanned,
-			exportExtras: saveExtras,
-			selector: selector,
-			mapName: map.name,
-			tagsJson: tagsJson(),
-			extraFieldsJson: JSON.stringify(getAllFieldDefs()),
-		});
-	const csvPath = () => cmd.storeExportCsv(selector);
-	const geojsonPath = () => cmd.storeExportGeojson(selector, tagsJson());
+  const jsonPath = () =>
+    cmd.storeExportJson({
+      exportZoom: saveZoom,
+      exportUnpanned: bypassUnpanned,
+      exportExtras: saveExtras,
+      selector: selector,
+      mapName: map.name,
+      tagsJson: tagsJson(),
+      extraFieldsJson: JSON.stringify(getAllFieldDefs()),
+    });
+  const csvPath = () => cmd.storeExportCsv(selector);
+  const geojsonPath = () => cmd.storeExportGeojson(selector, tagsJson());
 
-	const saveToFile = (srcPath: string, ext: string) =>
-		saveExportTempFile(srcPath, `${baseName}.${ext}`);
+  const saveToFile = (srcPath: string, ext: string) =>
+    saveExportTempFile(srcPath, `${baseName}.${ext}`);
 
-	const withFeedback = (run: () => Promise<boolean | void>, success: string) => async () => {
-		try {
-			const ok = await run();
-			if (ok !== false) toast(success);
-		} catch (e) {
-			log.error("[export] failed:", e);
-			toast(t("Export failed"));
-		}
-	};
+  const withFeedback =
+    (run: () => Promise<string | false>, success: (name: string) => string) =>
+    async () => {
+      try {
+        const savedName = await run();
+        if (savedName !== false) toast(success(savedName));
+      } catch (e) {
+        log.error("[export] failed:", e);
+        toast(t("Export failed"));
+      }
+    };
 
-	const copyJson = withFeedback(
-		async () =>
-			navigator.clipboard.writeText(await (await fetch(mmaBufUrl(await jsonPath()))).text()),
-		t("Copied JSON to clipboard"),
-	);
-	const downloadJson = withFeedback(
-		async () => saveToFile(await jsonPath(), "json"),
-		t("Downloaded {file}", { file: `${baseName}.json` }),
-	);
+  const copyJson = withFeedback(
+    async () =>
+      navigator.clipboard.writeText(
+        await (await fetch(mmaBufUrl(await jsonPath()))).text(),
+      ),
+    t("Copied JSON to clipboard"),
+  );
+  const downloadJson = withFeedback(
+    async () => saveToFile(await jsonPath(), "json"),
+    (file) => t("Downloaded {file}", { file }),
+  );
 
-	const copyCsv = withFeedback(
-		async () =>
-			navigator.clipboard.writeText(await (await fetch(mmaBufUrl(await csvPath()))).text()),
-		t("Copied CSV to clipboard"),
-	);
-	const downloadCsv = withFeedback(
-		async () => saveToFile(await csvPath(), "csv"),
-		t("Downloaded {file}", { file: `${baseName}.csv` }),
-	);
+  const copyCsv = withFeedback(
+    async () =>
+      navigator.clipboard.writeText(
+        await (await fetch(mmaBufUrl(await csvPath()))).text(),
+      ),
+    t("Copied CSV to clipboard"),
+  );
+  const downloadCsv = withFeedback(
+    async () => saveToFile(await csvPath(), "csv"),
+    (file) => t("Downloaded {file}", { file }),
+  );
 
-	const downloadGeoJson = withFeedback(
-		async () => saveToFile(await geojsonPath(), "geojson"),
-		t("Downloaded {file}", { file: `${baseName}.geojson` }),
-	);
+  const downloadGeoJson = withFeedback(
+    async () => saveToFile(await geojsonPath(), "geojson"),
+    (file) => t("Downloaded {file}", { file }),
+  );
 
-	return (
-		<Dialog open onOpenChange={(open) => !open && onClose()}>
-			<DialogContent title={t("Export")} className="export-modal">
-				<div className="export-modal__settings">
-					<div className="export-modal__filename">
-						<label htmlFor={`${uid}name`}>{t("File name:")}</label>
-						<TextInput
-							id={`${uid}name`}
-							type="text"
-							name="name"
-							value={fileName}
-							onChange={(e) => setFileName(e.target.value)}
-							autoFocus
-						/>
-					</div>
-					<div className="export-modal__fieldset">
-						<label>
-							<Radio
-								name="selection"
-								value="all"
-								checked={pick.pick === "all"}
-								onChange={() => setPick({ pick: "all" })}
-							/>
-							{t(
-								{
-									one: "Export everything ({n} location)",
-									other: "Export everything ({n} locations)",
-								},
-								{ n: locationCount },
-							)}
-						</label>
-						<label>
-							<Radio
-								name="selection"
-								value="selected"
-								checked={pick.pick === "selection"}
-								onChange={() => setPick({ pick: "selection" })}
-								disabled={selCount === 0}
-							/>
-							<span style={selCount === 0 ? { opacity: 0.7 } : undefined}>
-								{t(
-									{
-										one: "Export selection ({n} location)",
-										other: "Export selection ({n} locations)",
-									},
-									{ n: selCount },
-								)}
-							</span>
-						</label>
-					</div>
-					<div className="export-modal__fieldset">
-						<label>
-							<Checkbox
-								name="zoom"
-								checked={saveZoom}
-								onChange={(e) => setSaveZoom(e.target.checked)}
-							/>
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent title={t("Export")} className="export-modal">
+        <div className="export-modal__settings">
+          <div className="export-modal__filename">
+            <label htmlFor={`${uid}name`}>{t("File name:")}</label>
+            <TextInput
+              id={`${uid}name`}
+              type="text"
+              name="name"
+              value={fileName}
+              onChange={(e) => setFileName(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="export-modal__fieldset">
+            <label>
+              <Radio
+                name="selection"
+                value="all"
+                checked={pick.pick === "all"}
+                onChange={() => setPick({ pick: "all" })}
+              />
+              {t(
+                {
+                  one: "Export everything ({n} location)",
+                  other: "Export everything ({n} locations)",
+                },
+                { n: locationCount },
+              )}
+            </label>
+            <label>
+              <Radio
+                name="selection"
+                value="selected"
+                checked={pick.pick === "selection"}
+                onChange={() => setPick({ pick: "selection" })}
+                disabled={selCount === 0}
+              />
+              <span style={selCount === 0 ? { opacity: 0.7 } : undefined}>
+                {t(
+                  {
+                    one: "Export selection ({n} location)",
+                    other: "Export selection ({n} locations)",
+                  },
+                  { n: selCount },
+                )}
+              </span>
+            </label>
+          </div>
+          <div className="export-modal__fieldset">
+            <label>
+              <Checkbox
+                name="zoom"
+                checked={saveZoom}
+                onChange={(e) => setSaveZoom(e.target.checked)}
+              />
 
-							{t("Save zoom levels")}
-						</label>
-						<label>
-							<Checkbox
-								name="extras"
-								checked={saveExtras}
-								onChange={(e) => setSaveExtras(e.target.checked)}
-							/>
+              {t("Save zoom levels")}
+            </label>
+            <label>
+              <Checkbox
+                name="extras"
+                checked={saveExtras}
+                onChange={(e) => setSaveExtras(e.target.checked)}
+              />
 
-							{t("Save app data")}
-							<br />
-							<small className="export-modal__help">
-								{t(
-									"Include app-specific data like tags. Not including this makes the file smaller,\n\t\t\t\t\t\t\t\twhich can help when uploading maps with 100K+ locations to GeoGuessr.",
-								)}
-							</small>
-						</label>
-						<label>
-							<Checkbox
-								name="unpanned"
-								checked={bypassUnpanned}
-								onChange={(e) => setBypassUnpanned(e.target.checked)}
-							/>
+              {t("Save app data")}
+              <br />
+              <small className="export-modal__help">
+                {t(
+                  "Include app-specific data like tags. Not including this makes the file smaller,\n\t\t\t\t\t\t\t\twhich can help when uploading maps with 100K+ locations to GeoGuessr.",
+                )}
+              </small>
+            </label>
+            <label>
+              <Checkbox
+                name="unpanned"
+                checked={bypassUnpanned}
+                onChange={(e) => setBypassUnpanned(e.target.checked)}
+              />
 
-							{t("Bypass GeoGuessr auto-panning for locations with 0 heading")}
-							<br />
-							<small className="export-modal__help">
-								{t(
-									"GeoGuessr auto-pans locations that point straight north along the road. To keep your\n\t\t\t\t\t\t\t\tunpanned locations unpanned, enable this option.",
-								)}
-							</small>
-						</label>
-					</div>
-				</div>
-				<div className="export-modal__formats">
-					<div className="export-modal__format">
-						<h3 className="export-modal__subhead">{t("As JSON (recommended)")}</h3>
-						<div className="export-modal__export-buttons">
-							<Button
-								onClick={() => void copyJson()}
-								disabled={!navigator.clipboard}
-								data-qa="json-copy"
-							>
-								{t("Copy")}
-							</Button>
-							<Button onClick={() => void downloadJson()} data-qa="json-dl">
-								{t("Download")}
-							</Button>
-						</div>
-					</div>
-					<div className="export-modal__format">
-						<h3 className="export-modal__subhead">{t("As CSV")}</h3>
-						<p>
-							<Trans
-								msg={"CSV exports do {not} retain camera orientation and pano\u00A0IDs."}
-								not={<em>{t("not")}</em>}
-							/>
-						</p>
-						<div className="export-modal__export-buttons">
-							<Button
-								onClick={() => void copyCsv()}
-								disabled={!navigator.clipboard}
-								data-qa="csv-copy"
-							>
-								{t("Copy")}
-							</Button>
-							<Button onClick={() => void downloadCsv()} data-qa="csv-dl">
-								{t("Download")}
-							</Button>
-						</div>
-					</div>
-					<div className="export-modal__format">
-						<h3 className="export-modal__subhead">{t("As GeoJSON")}</h3>
-						<p>{t("For use in non-GeoGuessr mapping tools.")}</p>
-						<div className="export-modal__export-buttons">
-							<Button onClick={() => void downloadGeoJson()} data-qa="geojson-download">
-								{t("Download")}
-							</Button>
-						</div>
-					</div>
-				</div>
-			</DialogContent>
-		</Dialog>
-	);
+              {t("Bypass GeoGuessr auto-panning for locations with 0 heading")}
+              <br />
+              <small className="export-modal__help">
+                {t(
+                  "GeoGuessr auto-pans locations that point straight north along the road. To keep your\n\t\t\t\t\t\t\t\tunpanned locations unpanned, enable this option.",
+                )}
+              </small>
+            </label>
+          </div>
+        </div>
+        <div className="export-modal__formats">
+          <div className="export-modal__format">
+            <h3 className="export-modal__subhead">
+              {t("As JSON (recommended)")}
+            </h3>
+            <div className="export-modal__export-buttons">
+              <Button
+                onClick={() => void copyJson()}
+                disabled={!navigator.clipboard}
+                data-qa="json-copy"
+              >
+                {t("Copy")}
+              </Button>
+              <Button onClick={() => void downloadJson()} data-qa="json-dl">
+                {t("Download")}
+              </Button>
+            </div>
+          </div>
+          <div className="export-modal__format">
+            <h3 className="export-modal__subhead">{t("As CSV")}</h3>
+            <p>
+              <Trans
+                msg={
+                  "CSV exports do {not} retain camera orientation and pano\u00A0IDs."
+                }
+                not={<em>{t("not")}</em>}
+              />
+            </p>
+            <div className="export-modal__export-buttons">
+              <Button
+                onClick={() => void copyCsv()}
+                disabled={!navigator.clipboard}
+                data-qa="csv-copy"
+              >
+                {t("Copy")}
+              </Button>
+              <Button onClick={() => void downloadCsv()} data-qa="csv-dl">
+                {t("Download")}
+              </Button>
+            </div>
+          </div>
+          <div className="export-modal__format">
+            <h3 className="export-modal__subhead">{t("As GeoJSON")}</h3>
+            <p>{t("For use in non-GeoGuessr mapping tools.")}</p>
+            <div className="export-modal__export-buttons">
+              <Button
+                onClick={() => void downloadGeoJson()}
+                data-qa="geojson-download"
+              >
+                {t("Download")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/app/src/lib/util/fileName.ts
+++ b/app/src/lib/util/fileName.ts
@@ -1,0 +1,4 @@
+/** Return the last path segment for a native or URL-style path. */
+export function fileNameFromPath(path: string): string {
+  return path.split(/[/\\]/).at(-1) ?? path;
+}

--- a/app/src/lib/util/tauri.ts
+++ b/app/src/lib/util/tauri.ts
@@ -2,48 +2,59 @@
 import { save } from "@tauri-apps/plugin-dialog";
 import { cmd } from "@/lib/commands";
 import { downloadBlob, isWeb, mmaBufUrl } from "@/lib/util/util";
+import { fileNameFromPath } from "@/lib/util/fileName";
 
 // In a browser (web-serve) there's no native save dialog that returns a path for the
 // backend to write to. Use the File System Access API to let the user pick a destination
 // and stream the already-built temp export straight into it (no full read into memory).
 // Falls back to a plain download where that API is unavailable. Returns false if cancelled.
-async function downloadInBrowser(srcPath: string, fileName: string): Promise<boolean> {
-	const url = mmaBufUrl(srcPath);
-	const picker = (
-		window as unknown as {
-			showSaveFilePicker?: (o: { suggestedName?: string }) => Promise<FileSystemFileHandle>;
-		}
-	).showSaveFilePicker;
-	if (picker) {
-		let handle: FileSystemFileHandle;
-		try {
-			handle = await picker({ suggestedName: fileName });
-		} catch (e) {
-			if (e instanceof DOMException && e.name === "AbortError") return false;
-			throw e;
-		}
-		const res = await fetch(url);
-		if (!res.body) throw new Error("export stream unavailable");
-		// Reached only behind the showSaveFilePicker feature test above, which the lint rule
-		// can't see; without the picker we never get here and fall through to downloadBlob.
-		// eslint-disable-next-line local/no-unsupported-builtins
-		await res.body.pipeTo((await handle.createWritable()) as unknown as WritableStream<Uint8Array>);
-		return true;
-	}
-	downloadBlob(await (await fetch(url)).blob(), fileName);
-	return true;
+async function downloadInBrowser(
+  srcPath: string,
+  fileName: string,
+): Promise<string | false> {
+  const url = mmaBufUrl(srcPath);
+  const picker = (
+    window as unknown as {
+      showSaveFilePicker?: (o: {
+        suggestedName?: string;
+      }) => Promise<FileSystemFileHandle>;
+    }
+  ).showSaveFilePicker;
+  if (picker) {
+    let handle: FileSystemFileHandle;
+    try {
+      handle = await picker({ suggestedName: fileName });
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return false;
+      throw e;
+    }
+    const res = await fetch(url);
+    if (!res.body) throw new Error("export stream unavailable");
+    // Reached only behind the showSaveFilePicker feature test above, which the lint rule
+    // can't see; without the picker we never get here and fall through to downloadBlob.
+    // eslint-disable-next-line local/no-unsupported-builtins
+    await res.body.pipeTo(
+      (await handle.createWritable()) as unknown as WritableStream<Uint8Array>,
+    );
+    return handle.name;
+  }
+  downloadBlob(await (await fetch(url)).blob(), fileName);
+  return fileName;
 }
 
 /** Prompt for a destination and move a temp export file there (native dialog in
  *  Tauri, File System Access / download in the browser). False = cancelled. */
-export async function saveExportTempFile(srcPath: string, fileName: string): Promise<boolean> {
-	if (isWeb()) return downloadInBrowser(srcPath, fileName);
-	const ext = fileName.split(".").pop() ?? "";
-	const dest = await save({
-		defaultPath: fileName,
-		filters: [{ name: ext.toUpperCase(), extensions: [ext] }],
-	});
-	if (!dest) return false;
-	await cmd.storeSaveExportFile(srcPath, dest);
-	return true;
+export async function saveExportTempFile(
+  srcPath: string,
+  fileName: string,
+): Promise<string | false> {
+  if (isWeb()) return downloadInBrowser(srcPath, fileName);
+  const ext = fileName.split(".").pop() ?? "";
+  const dest = await save({
+    defaultPath: fileName,
+    filters: [{ name: ext.toUpperCase(), extensions: [ext] }],
+  });
+  if (!dest) return false;
+  await cmd.storeSaveExportFile(srcPath, dest);
+  return fileNameFromPath(dest);
 }

--- a/app/test/unit/tauri.test.ts
+++ b/app/test/unit/tauri.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { fileNameFromPath } from "@/lib/util/fileName";
+
+describe("fileNameFromPath", () => {
+  it("returns the final path segment for POSIX paths", () => {
+    expect(fileNameFromPath("/tmp/export.json")).toBe("export.json");
+  });
+
+  it("returns the final path segment for Windows paths", () => {
+    expect(fileNameFromPath("C:\\Users\\me\\Downloads\\custom-name.csv")).toBe(
+      "custom-name.csv",
+    );
+  });
+});


### PR DESCRIPTION
Fix the export success toast so it uses the filename the user actually saved, not the suggested default name.\n\nAlso adds a small pure helper for path-to-filename extraction with regression tests for POSIX and Windows paths.